### PR TITLE
[WIP] Create top-level root views to separate logged in and out

### DIFF
--- a/app/renderer/components/RootView.js
+++ b/app/renderer/components/RootView.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import View from 'components/View';
+import rootContainer from 'containers/Root';
+
+const RootView = ({component}) => (
+	<View component={component} activeView={rootContainer.state.activeView}/>
+);
+
+export default RootView;

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -38,8 +38,8 @@ const setAppWindowBounds = () => {
 
 class LoginContainer extends Container {
 	state = {
-		portfolios: null,
 		activeView: 'LoginBox',
+		portfolios: null,
 		selectedPortfolioId: config.get('lastActivePortfolioId'),
 		progress: 0,
 	};

--- a/app/renderer/containers/Root.js
+++ b/app/renderer/containers/Root.js
@@ -1,0 +1,40 @@
+import {remote} from 'electron';
+import ipc from 'electron-better-ipc';
+import {Container} from 'unstated';
+
+const config = remote.require('./config');
+// TODO: Uncomment this before we do the public release
+/// if (is.development) {
+window._config = config;
+/// }
+
+class RootContainer extends Container {
+	state = {
+		activeView: 'Login',
+	};
+
+	setActiveView(activeView) {
+		this.setState({activeView});
+	}
+}
+
+const rootContainer = new RootContainer();
+
+function handleDarkMode() {
+	const applyDarkMode = () => {
+		const darkMode = config.get('darkMode');
+		rootContainer.setState({darkMode});
+		document.documentElement.classList.toggle('dark-mode', darkMode);
+	};
+
+	ipc.on('toggle-dark-mode', () => {
+		config.set('darkMode', !config.get('darkMode'));
+		applyDarkMode();
+	});
+
+	applyDarkMode();
+}
+
+handleDarkMode();
+
+export default rootContainer;

--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {render} from 'react-dom';
 import {Provider} from 'unstated';
 import UNSTATED from 'unstated-debug';
-import App from './views/App';
+import Root from './views/Root';
 
 UNSTATED.isEnabled = is.development;
 UNSTATED.logStateChanges = false;
@@ -14,6 +14,6 @@ require('electron-unhandled')({
 
 render((
 	<Provider>
-		<App/>
+		<Root/>
 	</Provider>
 ), document.querySelector('#root'));

--- a/app/renderer/views/App.js
+++ b/app/renderer/views/App.js
@@ -1,7 +1,5 @@
-import {hot} from 'react-hot-loader';
 import React from 'react';
 import {Subscribe} from 'unstated';
-import '../styles/index.scss';
 import appContainer from 'containers/App';
 import AppView from 'components/AppView';
 import Login from './Login';
@@ -10,7 +8,6 @@ import Swap from './Swap';
 import Exchange from './Exchange';
 import Trades from './Trades';
 import Preferences from './Preferences';
-import ComponentsPreview from './ComponentsPreview';
 
 const App = () => (
 	<Subscribe to={[appContainer]}>
@@ -22,10 +19,9 @@ const App = () => (
 				<AppView component={Exchange}/>
 				<AppView component={Trades}/>
 				<AppView component={Preferences}/>
-				<AppView component={ComponentsPreview}/>
 			</React.Fragment>
 		)}
 	</Subscribe>
 );
 
-export default hot(module)(App);
+export default App;

--- a/app/renderer/views/Root.js
+++ b/app/renderer/views/Root.js
@@ -1,0 +1,23 @@
+import {hot} from 'react-hot-loader';
+import React from 'react';
+import {Subscribe} from 'unstated';
+import '../styles/index.scss';
+import rootContainer from 'containers/App';
+import RootView from 'components/RootView';
+import Login from './Login';
+import App from './App';
+import ComponentsPreview from './ComponentsPreview';
+
+const Root = () => (
+	<Subscribe to={[rootContainer]}>
+		{() => (
+			<React.Fragment>
+				<RootView component={Login}/>
+				<RootView component={App}/>
+				<RootView component={ComponentsPreview}/>
+			</React.Fragment>
+		)}
+	</Subscribe>
+);
+
+export default hot(module)(Root);


### PR DESCRIPTION
This adds a `RootContainer` which manages the whole app. This changes the responsibility of `AppContainer` to only handle the logged-in app. I thought this would be a cleaner separation, but I'm not entirely sure this is the correct approach. I'll need to think about it more. The task of the `RootContainer` is to change between the `Login` and `App` views depending on whether the user is logged-in or not.