### PR TITLE
Improve sell order handling

### DIFF
--- a/app/renderer/views/Exchange/Swaps.js
+++ b/app/renderer/views/Exchange/Swaps.js
@@ -72,10 +72,14 @@ const All = () => (
 const Split = () => {
 	const {state} = exchangeContainer;
 
-	const filteredData = state.swapHistory.filter(x =>
-		x.baseCurrency === state.baseCurrency &&
-		x.quoteCurrency === state.quoteCurrency
-	);
+	const filteredData = state.swapHistory.filter(swap => {
+		const tradingPair = [state.baseCurrency, state.quoteCurrency];
+
+		return (
+			tradingPair.includes(swap.baseCurrency) &&
+			tradingPair.includes(swap.quoteCurrency)
+		);
+	});
 
 	return (
 		<SwapList swaps={filteredData}/>

--- a/app/renderer/views/Exchange/Swaps.js
+++ b/app/renderer/views/Exchange/Swaps.js
@@ -38,8 +38,8 @@ const SwapItem = ({swap}) => (
 	<div className="row">
 		<div className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD.MM')}</div>
 		<div className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</div>
-		<div className="sell-amount">-{swap.quoteCurrencyAmount} {swap.quoteCurrency}</div>
-		<div className="buy-amount">+{swap.baseCurrencyAmount} {swap.baseCurrency}</div>
+		<div className="base-amount">+{swap.baseCurrencyAmount} {swap.baseCurrency}</div>
+		<div className="quote-amount">-{swap.quoteCurrencyAmount} {swap.quoteCurrency}</div>
 		<div className="status">
 			<div className="status__icon" data-status={swap.status}>{swap.statusFormatted}</div>
 		</div>

--- a/app/renderer/views/Exchange/Swaps.scss
+++ b/app/renderer/views/Exchange/Swaps.scss
@@ -69,7 +69,7 @@
 			.row {
 				display: grid;
 				grid-template-areas:
-					'pairs sell-amount buy-amount'
+					'pairs base-amount quote-amount'
 					'timestamp status view';
 				grid-template-columns: repeat(3, 1fr);
 				grid-gap: 8px;
@@ -92,13 +92,13 @@
 					grid-area: pairs;
 				}
 
-				.sell-amount {
-					grid-area: sell-amount;
+				.base-amount {
+					grid-area: base-amount;
 					justify-self: center;
 				}
 
-				.buy-amount {
-					grid-area: buy-amount;
+				.quote-amount {
+					grid-area: quote-amount;
 					justify-self: end;
 				}
 
@@ -115,16 +115,16 @@
 
 			@media only screen and (min-width: 1260px) {
 				.row {
-					grid-template-areas: 'timestamp pairs sell-amount buy-amount status view';
+					grid-template-areas: 'timestamp pairs base-amount quote-amount status view';
 					grid-template-columns: 11% 18% 22% 22%;
 					justify-content: unset;
 					white-space: unset;
 
-					.sell-amount {
+					.base-amount {
 						justify-self: start;
 					}
 
-					.buy-amount {
+					.quote-amount {
 						justify-self: start;
 					}
 
@@ -160,11 +160,11 @@
 				color: var(--text-color);
 			}
 
-			.sell-amount {
+			.quote-amount {
 				color: var(--red-color);
 			}
 
-			.buy-amount {
+			.base-amount {
 				color: var(--green-color);
 			}
 

--- a/app/renderer/views/Trades.js
+++ b/app/renderer/views/Trades.js
@@ -77,8 +77,8 @@ const SwapItem = ({swap}) => (
 	<tr>
 		<td className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD.MM.YY')}</td>
 		<td className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</td>
-		<td className="sell-amount">-{swap.broadcast.quoteCurrencyAmount} {swap.quoteCurrency}</td>
-		<td className="buy-amount">+{swap.broadcast.baseCurrencyAmount} {swap.baseCurrency}</td>
+		<td className="base-amount">+{swap.baseCurrencyAmount} {swap.baseCurrency}</td>
+		<td className="quote-amount">-{swap.quoteCurrencyAmount} {swap.quoteCurrency}</td>
 		<td className="status">
 			<div className="status__icon" data-status={swap.status}>{swap.statusFormatted}</div>
 		</td>


### PR DESCRIPTION
Fixes #184 and fixes lukechilds/hyperdex-bugtracker#15

See https://github.com/lukechilds/hyperdex-bugtracker/issues/15#issuecomment-387599771 for info.

Also, this breaks the `<SwapItem/>` component on the Trades view. I tried copying the new markup over but the it gets the colours styles but remove the positioning styles. I looked in the Trades styles but couldn't see anything regarding to positioning. Are you able to have a look at this.

It also seems confusing that the same component is used in two views and borrows some styles from both the views but then also has some unique styles. I think we should definitely consolidate this into a single component used in both places. It should display the same everywhere with both the cancel button and the view button in both places.