### PR TITLE
Show swap error codes

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -145,8 +145,7 @@ class SwapDB {
 				// TODO: Add error messages once we have errors documented
 				// https://github.com/lukechilds/hyperdex/issues/180
 				swap.error = {
-					code: message.error,
-					message: undefined,
+					message: `Error Code: ${message.error}`,
 				};
 			}
 

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -74,6 +74,7 @@ class SwapDB {
 			timeStarted,
 			status: 'pending',
 			statusFormatted: 'pending',
+			error: false,
 			progress: 0,
 			baseCurrency: response.base,
 			quoteCurrency: response.rel,
@@ -140,6 +141,13 @@ class SwapDB {
 
 			if (message.method === 'failed') {
 				swap.status = 'failed';
+
+				// TODO: Add error messages once we have errors documented
+				// https://github.com/lukechilds/hyperdex/issues/180
+				swap.error = {
+					code: message.error,
+					message: undefined,
+				}
 			}
 
 			swap.statusFormatted = swap.status;

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -147,7 +147,7 @@ class SwapDB {
 				swap.error = {
 					code: message.error,
 					message: undefined,
-				}
+				};
 			}
 
 			swap.statusFormatted = swap.status;

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -145,6 +145,7 @@ class SwapDB {
 				// TODO: Add error messages once we have errors documented
 				// https://github.com/lukechilds/hyperdex/issues/180
 				swap.error = {
+					code: message.error,
 					message: `Error Code: ${message.error}`,
 				};
 			}

--- a/app/renderer/views/Exchange/SwapDetails.js
+++ b/app/renderer/views/Exchange/SwapDetails.js
@@ -133,7 +133,7 @@ class SwapDetails extends React.Component {
 								{(swap.status === 'failed' && swap.error) && (
 									<React.Fragment>
 										<br/>
-										Error Code: {swap.error.code}
+										{swap.error.message}
 									</React.Fragment>
 								)}
 							</p>

--- a/app/renderer/views/Exchange/SwapDetails.js
+++ b/app/renderer/views/Exchange/SwapDetails.js
@@ -128,7 +128,15 @@ class SwapDetails extends React.Component {
 						</div>
 						<div className="section progress">
 							<Progress value={swap.progress}/>
-							<p>{title(swap.statusFormatted)}</p>
+							<p>
+								{title(swap.statusFormatted)}
+								{(swap.status === 'failed' && swap.error) && (
+									<React.Fragment>
+										<br/>
+										Error Code: {swap.error.code}
+									</React.Fragment>
+								)}
+							</p>
 						</div>
 						<div className="section details">
 							<h4>Your offer</h4>


### PR DESCRIPTION
Resolves #194
Also makes a start on https://github.com/lukechilds/hyperdex/issues/194

This PR adds a new `error` property to the swap object. By default it is false so we can just do simple truthy checks on it.

If there is an error it will look like this:

```js
swap.error = {
	code: Number,
	message: String || undefined,
}
```

Currently messages are always undefined but this will change as we get more [documentation from James](https://docs.google.com/spreadsheets/d/1blgmrJCZ-SfYaJdTTVdk717kZ43R4yzm9YIW2Bt--EM/edit?usp=sharing)

I'm just displaying the code in the swap details modal but we should display a helpful message if available.

I've just added it to the modal in a basic way, feel free to change it  or style it differently.

![screen shot 2018-05-09 at 1 28 49 pm](https://user-images.githubusercontent.com/2123375/39799042-fa1b800e-538c-11e8-90b1-275af30f4fe7.png)
