### PR TITLE
Show percentage saved from order placed

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -94,6 +94,7 @@ class SwapDB {
 				baseCurrencyAmount: undefined,
 				quoteCurrencyAmount: undefined,
 				price: undefined,
+				percentCheaperThanRequested: undefined,
 			},
 			transactions: [],
 			_debug: {
@@ -136,6 +137,7 @@ class SwapDB {
 				swap.executed.baseCurrencyAmount = swap.baseCurrencyAmount;
 				swap.executed.quoteCurrencyAmount = swap.quoteCurrencyAmount;
 				swap.executed.price = swap.price;
+				swap.executed.percentCheaperThanRequested = roundTo(100 - ((swap.executed.price / swap.requested.price) * 100), 2);
 			}
 
 			if (message.method === 'failed') {

--- a/app/renderer/views/Exchange/SwapDetails.js
+++ b/app/renderer/views/Exchange/SwapDetails.js
@@ -135,6 +135,9 @@ class SwapDetails extends React.Component {
 							<div className="offer">
 								{prices}
 							</div>
+							{swap.executed.percentCheaperThanRequested > 0 && (
+								<p>Executed price was {swap.executed.percentCheaperThanRequested}% cheaper than requested!</p>
+							)}
 							{hasTransactions && (
 								<React.Fragment>
 									<h4>Transactions</h4>

--- a/app/renderer/views/Exchange/SwapDetails.js
+++ b/app/renderer/views/Exchange/SwapDetails.js
@@ -131,13 +131,15 @@ class SwapDetails extends React.Component {
 							<p>{title(swap.statusFormatted)}</p>
 						</div>
 						<div className="section details">
-							<h4>Your offer</h4>
-							<div className="offer">
-								{prices}
+							<div className="offer-wrapper">
+								<h4>Your offer</h4>
+								<div className="offer">
+									{prices}
+								</div>
+								{swap.executed.percentCheaperThanRequested > 0 && (
+									<p>The executed price was {swap.executed.percentCheaperThanRequested}% cheaper than requested!</p>
+								)}
 							</div>
-							{swap.executed.percentCheaperThanRequested > 0 && (
-								<p>Executed price was {swap.executed.percentCheaperThanRequested}% cheaper than requested!</p>
-							)}
 							{hasTransactions && (
 								<React.Fragment>
 									<h4>Transactions</h4>

--- a/app/renderer/views/Exchange/SwapDetails.scss
+++ b/app/renderer/views/Exchange/SwapDetails.scss
@@ -84,7 +84,6 @@
 		.transactions {
 			display: flex;
 			justify-content: space-between;
-			margin-bottom: 40px;
 
 			h6 {
 				font-size: 12px;
@@ -97,6 +96,14 @@
 				margin: 0;
 				font-size: 14px;
 				color: rgba(255, 255, 255, 0.8);
+			}
+		}
+
+		.offer-wrapper {
+			margin-bottom: 40px;
+
+			> p {
+				margin-top: 10px;
 			}
 		}
 
@@ -120,6 +127,7 @@
 
 		.transactions {
 			justify-content: space-evenly;
+			margin-bottom: 40px;
 
 			.item {
 				display: flex;


### PR DESCRIPTION
Resolves #195

![screen shot 2018-05-09 at 1 50 15 pm](https://user-images.githubusercontent.com/2123375/39800095-e7168018-5390-11e8-81e3-3b66282d6015.png)

Exposes as `swap.executed.percentCheaperThanRequested` property. I know that's a bit verbose, open to a better name.

Also I know it looks pretty out of place in the UI and doesn't fit well with the rest of the modal. Happy for you to play with this and totally change it. I just wanted to get it in there for you to see.