### PR TITLE
Don't show unmatched swaps as failed

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -163,6 +163,8 @@ class SwapDB {
 
 				swap.statusFormatted = `swap ${swapProgress}/${swapTransactions.length}`;
 				swap.progress = (swapProgress + MATCHED_STEP) / TOTAL_PROGRESS_STEPS;
+			} else if (swap.status === 'failed' && message.error === -9999) {
+				swap.statusFormatted = 'unmatched';
 			}
 		});
 

--- a/app/renderer/views/Exchange/Swaps.scss
+++ b/app/renderer/views/Exchange/Swaps.scss
@@ -170,7 +170,7 @@
 
 			.status {
 				&__icon {
-					width: 60px;
+					width: 62px;
 					padding: 1px 2px;
 					font-size: 10px;
 					text-align: center;


### PR DESCRIPTION
Resolves #179 and resolves lukechilds/hyperdex-bugtracker#9

This will set `swap.statusFormatted` to `unmatched` instead of `failed` for any failed swaps with an error code of `-9999`.

Hopefully it'll be more clear to the users that they just didn't get a match and we'll get less "failed swaps" complaints.

<img width="691" alt="screen shot 2018-05-09 at 5 57 23 pm" src="https://user-images.githubusercontent.com/2123375/39811307-76db6800-53b2-11e8-8368-6cb47ac0f918.png">
