### PR TITLE
Add ability to toggle currencies

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -97,6 +97,13 @@ export default class Api {
 		return Promise.all(requests);
 	}
 
+	disableCoin(coin) {
+		return this.request({
+			method: 'disable',
+			coin,
+		});
+	}
+
 	portfolio() {
 		return this.request({method: 'portfolio'});
 	}

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -7,6 +7,7 @@ import roundTo from 'round-to';
 import {Container} from 'unstated';
 import loginContainer from 'containers/Login';
 import {appViews} from '../../constants';
+import supportedCurrencies from '../../marketmaker/supported-currencies';
 import fireEvery from '../fire-every';
 import {formatCurrency} from '../util';
 
@@ -69,7 +70,7 @@ class AppContainer extends Container {
 		const FIVE_MINUTES = 1000 * 60 * 5;
 
 		await fireEvery(async () => {
-			this.coinPrices = await Promise.all(this.enabledCoins.map(symbol => getTickerData(symbol)));
+			this.coinPrices = await Promise.all(supportedCurrencies.map(currency => getTickerData(currency.coin)));
 		}, FIVE_MINUTES);
 	}
 

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -34,12 +34,12 @@ const getTickerData = async symbol => {
 class AppContainer extends Container {
 	state = {
 		activeView: 'Login',
+		enabledCoins: config.get('enabledCoins'),
 	};
 
 	constructor() {
 		super();
 		this.views = new Cycled(appViews);
-		this.enabledCoins = config.get('enabledCoins');
 
 		this.getSwapDB = new Promise(resolve => {
 			this.setSwapDB = resolve;
@@ -119,6 +119,24 @@ class AppContainer extends Container {
 
 	getCurrency(symbol) {
 		return this.state.currencies.find(x => x.coin === symbol);
+	}
+
+	enableCoin(coin) {
+		this.setState(prevState => {
+			this.api.enableCoin(coin);
+			const enabledCoins = [...prevState.enabledCoins, coin];
+			config.set('enabledCoins', enabledCoins);
+			return {enabledCoins};
+		});
+	}
+
+	disableCoin(coin) {
+		this.setState(prevState => {
+			this.api.disableCoin(coin);
+			const enabledCoins = prevState.enabledCoins.filter(enabledCoin => enabledCoin !== coin);
+			config.set('enabledCoins', enabledCoins);
+			return {enabledCoins};
+		});
 	}
 
 	logOut() {

--- a/app/renderer/containers/Dashboard.js
+++ b/app/renderer/containers/Dashboard.js
@@ -20,6 +20,12 @@ class DashboardContainer extends Container {
 	constructor() {
 		super();
 		this.currencyHistoryCache = new Map();
+
+		appContainer.subscribe(() => {
+			if (!appContainer.state.enabledCoins.includes(this.state.activeView)) {
+				this.setActiveView('Portfolio');
+			}
+		});
 	}
 
 	setActiveView = activeView => {

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -26,6 +26,21 @@ class ExchangeContainer extends Container {
 		appContainer.getSwapDB.then(swapDB => {
 			swapDB.on('change', this.setSwapHistory);
 		});
+
+		appContainer.subscribe(() => {
+			if (!appContainer.state.enabledCoins.includes(this.state.baseCurrency)) {
+				const newBaseCurrency = appContainer.state.enabledCoins.find(enabledCoin => {
+					return enabledCoin !== this.state.quoteCurrency;
+				});
+				this.setBaseCurrency(newBaseCurrency);
+			}
+			if (!appContainer.state.enabledCoins.includes(this.state.quoteCurrency)) {
+				const newQuoteCurrency = appContainer.state.enabledCoins.find(enabledCoin => {
+					return enabledCoin !== this.state.baseCurrency;
+				});
+				this.setQuoteCurrency(newQuoteCurrency);
+			}
+		});
 	}
 
 	setSwapHistory = async () => {

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -98,7 +98,6 @@ class LoginContainer extends Container {
 		window._swapDB = swapDB;
 		// }
 
-		// TODO: These should be changeable by the user
 		await Promise.all(appContainer.state.enabledCoins.map(x => api.enableCoin(x)));
 
 		await appContainer.watchCMC();

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -99,7 +99,7 @@ class LoginContainer extends Container {
 		// }
 
 		// TODO: These should be changeable by the user
-		await Promise.all(config.get('enabledCoins').map(x => api.enableCoin(x)));
+		await Promise.all(appContainer.state.enabledCoins.map(x => api.enableCoin(x)));
 
 		await appContainer.watchCMC();
 		await appContainer.watchCurrencies();

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -58,18 +58,21 @@ class Form extends React.Component {
 					<label>
 						Enabled Currencies:
 					</label>
-					{supportedCurrencies.map(currency => (
-						<label key={currency.coin} style={{display: 'block'}}>
-							<CurrencyIcon symbol={currency.coin}/>
-							{(coinlist.get(currency.coin, 'name') || currency.coin)} ({currency.coin})
-							<Input
-								type="checkbox"
-								value={currency.coin}
-								checked={this.state.enabledCoins.includes(currency.coin)}
-								onChange={this.toggleCurrency}
-							/>
-						</label>
-					))}
+					{supportedCurrencies
+						.filter(currency => currency.coin !== 'KMD')
+						.map(currency => (
+							<label key={currency.coin} style={{display: 'block'}}>
+								<CurrencyIcon symbol={currency.coin}/>
+								{(coinlist.get(currency.coin, 'name') || currency.coin)} ({currency.coin})
+								<Input
+									type="checkbox"
+									value={currency.coin}
+									checked={this.state.enabledCoins.includes(currency.coin)}
+									onChange={this.toggleCurrency}
+								/>
+							</label>
+						))
+					}
 				</div>
 			</React.Fragment>
 		);

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -2,6 +2,7 @@ import electron from 'electron';
 import React from 'react';
 import _ from 'lodash';
 import coinlist from 'coinlist';
+import appContainer from 'containers/App';
 import Input from 'components/Input';
 import CurrencyIcon from 'components/CurrencyIcon';
 import supportedCurrencies from '../../marketmaker/supported-currencies';
@@ -26,13 +27,19 @@ class Form extends React.Component {
 		this.persistState(name, value);
 	};
 
-	toggleCurrency = (value, event) => {
+	toggleCurrency = (coin, event) => {
 		const {checked} = event.target;
+		const {api} = appContainer;
 
 		this.setState(prevState => {
-			const enabledCoins = checked ?
-				[...prevState.enabledCoins, value] :
-				prevState.enabledCoins.filter(coin => coin !== value);
+			let enabledCoins;
+			if (checked) {
+				api.enableCoin(coin);
+				enabledCoins = [...prevState.enabledCoins, coin];
+			} else {
+				api.disableCoin(coin);
+				enabledCoins = prevState.enabledCoins.filter(enabledCoin => enabledCoin !== coin);
+			}
 
 			this.persistState('enabledCoins', enabledCoins);
 

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -2,6 +2,7 @@ import electron from 'electron';
 import React from 'react';
 import _ from 'lodash';
 import coinlist from 'coinlist';
+import {Subscribe} from 'unstated';
 import appContainer from 'containers/App';
 import Input from 'components/Input';
 import CurrencyIcon from 'components/CurrencyIcon';
@@ -14,7 +15,6 @@ const config = electron.remote.require('./config');
 class Form extends React.Component {
 	state = {
 		marketmakerUrl: config.get('marketmakerUrl') || '',
-		enabledCoins: config.get('enabledCoins') || [],
 	};
 
 	persistState = _.debounce((name, value) => {
@@ -29,22 +29,12 @@ class Form extends React.Component {
 
 	toggleCurrency = (coin, event) => {
 		const {checked} = event.target;
-		const {api} = appContainer;
 
-		this.setState(prevState => {
-			let enabledCoins;
-			if (checked) {
-				api.enableCoin(coin);
-				enabledCoins = [...prevState.enabledCoins, coin];
-			} else {
-				api.disableCoin(coin);
-				enabledCoins = prevState.enabledCoins.filter(enabledCoin => enabledCoin !== coin);
-			}
-
-			this.persistState('enabledCoins', enabledCoins);
-
-			return {enabledCoins};
-		});
+		if (checked) {
+			appContainer.enableCoin(coin);
+		} else {
+			appContainer.disableCoin(coin);
+		}
 	};
 
 	render() {
@@ -74,7 +64,7 @@ class Form extends React.Component {
 								<Input
 									type="checkbox"
 									value={currency.coin}
-									checked={this.state.enabledCoins.includes(currency.coin)}
+									checked={appContainer.state.enabledCoins.includes(currency.coin)}
 									onChange={this.toggleCurrency}
 								/>
 							</label>
@@ -87,14 +77,18 @@ class Form extends React.Component {
 }
 
 const Preferences = () => (
-	<TabView title="Preferences" className="Preferences">
-		<header>
-			<h2>Preferences</h2>
-		</header>
-		<main>
-			<Form/>
-		</main>
-	</TabView>
+	<Subscribe to={[appContainer]}>
+		{() => (
+			<TabView title="Preferences" className="Preferences">
+				<header>
+					<h2>Preferences</h2>
+				</header>
+				<main>
+					<Form/>
+				</main>
+			</TabView>
+		)}
+	</Subscribe>
 );
 
 export default Preferences;

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -1,7 +1,10 @@
 import electron from 'electron';
 import React from 'react';
 import _ from 'lodash';
+import coinlist from 'coinlist';
 import Input from 'components/Input';
+import CurrencyIcon from 'components/CurrencyIcon';
+import supportedCurrencies from '../../marketmaker/supported-currencies';
 import TabView from './TabView';
 import './Preferences.scss';
 
@@ -10,6 +13,7 @@ const config = electron.remote.require('./config');
 class Form extends React.Component {
 	state = {
 		marketmakerUrl: config.get('marketmakerUrl') || '',
+		enabledCoins: config.get('enabledCoins') || [],
 	};
 
 	persistState = _.debounce((name, value) => {
@@ -20,6 +24,20 @@ class Form extends React.Component {
 		const {name} = event.target;
 		this.setState({[name]: value});
 		this.persistState(name, value);
+	};
+
+	toggleCurrency = (value, event) => {
+		const {checked} = event.target;
+
+		this.setState(prevState => {
+			const enabledCoins = checked ?
+				[...prevState.enabledCoins, value] :
+				prevState.enabledCoins.filter(coin => coin !== value);
+
+			this.persistState('enabledCoins', enabledCoins);
+
+			return {enabledCoins};
+		});
 	};
 
 	render() {
@@ -35,6 +53,23 @@ class Form extends React.Component {
 						onChange={this.handleChange}
 						placeholder="Example: http://localhost:7783"
 					/>
+				</div>
+				<div className="form-group">
+					<label>
+						Enabled Currencies:
+					</label>
+					{supportedCurrencies.map(currency => (
+						<label key={currency.coin} style={{display: 'block'}}>
+							<CurrencyIcon symbol={currency.coin}/>
+							{(coinlist.get(currency.coin, 'name') || currency.coin)} ({currency.coin})
+							<Input
+								type="checkbox"
+								value={currency.coin}
+								checked={this.state.enabledCoins.includes(currency.coin)}
+								onChange={this.toggleCurrency}
+							/>
+						</label>
+					))}
 				</div>
 			</React.Fragment>
 		);

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -56,7 +56,7 @@ class Form extends React.Component {
 						Enabled Currencies:
 					</label>
 					{supportedCurrencies
-						.filter(currency => currency.coin !== 'KMD')
+						.filter(currency => !['KMD', 'CHIPS'].includes(currency.coin))
 						.map(currency => (
 							<label key={currency.coin} style={{display: 'block'}}>
 								<CurrencyIcon symbol={currency.coin}/>


### PR DESCRIPTION
Resolves #130 

This was a bit more involved than I thought. We have calls to `config.get('enabledCoins')` at different places in the code but it was sometimes stored and treated as a static property.

This meant updating currencies could mean that values on other places using `config.get('enabledCoins')` will become out of sync with the actual enabled coins. So I've moved `enabledCoins` into `appContainer.state` and now everything references it from there.

We should also probably refactor to use `appContainer.state.enabledCoins` everywhere in the app instead of `appContainer.state.currencies` which we poll `marketmaker` for.

At the moment, because most places use the `marketmaker` response if you enable a new currency and then switch to the dashboard view, there can be a delay of a few seconds and then suddenly your new currency will appear. This doesn't make sense because we know which currencies are enabled immediately.

This PR is already getting a bit heavy and it works as is, it's just not optimal. So the refactor should probably be in a follow up PR.

This needs a bit more testing before it's ready to merge. It'll break stuff if you disable a currency that's in the current trading pair.

Also, the UI needs a lot of 💄

![toggle-currencies](https://user-images.githubusercontent.com/2123375/39867725-75f39308-5480-11e8-8c32-d97705521721.gif)
