### PR TITLE
Prevent potential circular dependency

### DIFF
--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -6,7 +6,6 @@ import {minWindowSize} from '../../constants';
 import Api from '../api';
 import SwapDB from '../swap-db';
 import appContainer from './App';
-import dashboardContainer from './Dashboard';
 
 const config = remote.require('./config');
 const {getPortfolios, decryptSeedPhrase} = remote.require('./portfolio-util');
@@ -104,6 +103,11 @@ class LoginContainer extends Container {
 
 		await appContainer.watchCMC();
 		await appContainer.watchCurrencies();
+
+		// We have to use dynamic import here as Webpack is unable to resolve circular
+		// dependencies. Better to handle it here so that it's possible to import the
+		// App container in the Dashboard container.
+		const {default: dashboardContainer} = await import('./Dashboard');
 		await dashboardContainer.watchCurrencyHistory();
 
 		config.set('lastActivePortfolioId', portfolio.id);

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"babel-core": "^6.26.3",
 		"babel-eslint": "^8.2.3",
 		"babel-loader": "^7.1.4",
+		"babel-plugin-syntax-dynamic-import": "^6.18.0",
 		"babel-plugin-transform-class-properties": "^6.24.1",
 		"babel-preset-react": "^6.24.1",
 		"babel-preset-stage-3": "^6.24.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
 						'stage-3',
 					],
 					plugins: [
+						'syntax-dynamic-import',
 						['transform-class-properties', {spec: true}],
 						'react-hot-loader/babel',
 					],


### PR DESCRIPTION
Fixes https://github.com/lukechilds/hyperdex/pull/202#issuecomment-388318577

The problem was caused by a circular dependency. This should usually just be handled by the system, but Webpack is of course not able to...

`Containers/App` imports `Containers/Login` which imports `Containers/Dashboard`. It becomes a circular dependency then when we try to import `Containers/Dashboard` in `Containers/App`.

It still seems like it should have always been `undefined` then, right? Since variables cannot suddenly change their value. The thing is, Webpack transforms all imports, so this:

```js
console.log(appContainer);
```

Is transformed into this:

```js
console.log(containers_App__WEBPACK_IMPORTED_MODULE_3__["default"]);
```

And now it's suddenly an object property, which *can* change dynamically.

Gotta love modern web development...