### PR TITLE
Add currency util functions and allow overriding currency names

### DIFF
--- a/app/marketmaker/index.js
+++ b/app/marketmaker/index.js
@@ -8,7 +8,7 @@ const util = require('electron-util');
 const getPort = require('get-port');
 const logger = require('electron-timber');
 const makeDir = require('make-dir');
-const supportedCurrencies = require('./supported-currencies');
+const {supportedCurrencies} = require('./supported-currencies');
 
 // `electron-builder` uses different names
 const platformMapping = new Map([

--- a/app/marketmaker/supported-currencies.js
+++ b/app/marketmaker/supported-currencies.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const coinlist = require('coinlist');
+const _ = require('lodash');
 
 const supportedCurrencies = [
 	{
@@ -152,7 +153,7 @@ const supportedCurrencies = [
 	},
 ];
 
-const getCurrencySymbols = () => supportedCurrencies.map(currency => currency.coin);
+const getCurrencySymbols = () => _.orderBy(supportedCurrencies.map(currency => currency.coin));
 
 const getCurrencyName = symbol => {
 	const coinParams = supportedCurrencies.find(currency => currency.coin === symbol);

--- a/app/marketmaker/supported-currencies.js
+++ b/app/marketmaker/supported-currencies.js
@@ -3,6 +3,7 @@
 const supportedCurrencies = [
 	{
 		coin: 'KMD',
+		name: 'Komodo',
 		electrumServers: [
 			{
 				host: 'electrum1.cipig.net',
@@ -16,6 +17,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'BTC',
+		name: 'Bitcoin',
 		electrumServers: [
 			{
 				host: 'electrum1.cipig.net',
@@ -29,6 +31,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'REVS',
+		name: 'Revs',
 		asset: 'REVS',
 		rpcport: 10196,
 		electrumServers: [
@@ -44,6 +47,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'SUPERNET',
+		name: 'Supernet',
 		asset: 'SUPERNET',
 		rpcport: 11341,
 		electrumServers: [
@@ -59,6 +63,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'OOT',
+		name: 'Utrum',
 		asset: 'OOT',
 		rpcport: 12467,
 		electrumServers: [
@@ -74,6 +79,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'CHIPS',
+		name: 'Chips',
 		rpcport: 57776,
 		pubtype: 60,
 		p2shtype: 85,
@@ -92,6 +98,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'VTC',
+		name: 'Vertcoin',
 		rpcport: 5888,
 		pubtype: 71,
 		p2shtype: 5,
@@ -110,6 +117,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'LTC',
+		name: 'Litecoin',
 		rpcport: 9332,
 		pubtype: 48,
 		p2shtype: 5,
@@ -128,6 +136,7 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'DOGE',
+		name: 'Dogecoin',
 		rpcport: 22555,
 		pubtype: 30,
 		p2shtype: 22,

--- a/app/marketmaker/supported-currencies.js
+++ b/app/marketmaker/supported-currencies.js
@@ -161,8 +161,11 @@ const getCurrencyName = symbol => {
 	return coinParams.name || coinlist.get(symbol, 'name') || symbol;
 };
 
+const getCurrency = symbol => supportedCurrencies.find(currency => currency.coin === symbol);
+
 module.exports = {
 	supportedCurrencies,
 	getCurrencySymbols,
 	getCurrencyName,
+	getCurrency,
 };

--- a/app/marketmaker/supported-currencies.js
+++ b/app/marketmaker/supported-currencies.js
@@ -3,7 +3,6 @@
 const supportedCurrencies = [
 	{
 		coin: 'KMD',
-		name: 'Komodo',
 		electrumServers: [
 			{
 				host: 'electrum1.cipig.net',
@@ -17,7 +16,6 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'BTC',
-		name: 'Bitcoin',
 		electrumServers: [
 			{
 				host: 'electrum1.cipig.net',
@@ -98,7 +96,6 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'VTC',
-		name: 'Vertcoin',
 		rpcport: 5888,
 		pubtype: 71,
 		p2shtype: 5,
@@ -117,7 +114,6 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'LTC',
-		name: 'Litecoin',
 		rpcport: 9332,
 		pubtype: 48,
 		p2shtype: 5,
@@ -136,7 +132,6 @@ const supportedCurrencies = [
 	},
 	{
 		coin: 'DOGE',
-		name: 'Dogecoin',
 		rpcport: 22555,
 		pubtype: 30,
 		p2shtype: 22,

--- a/app/marketmaker/supported-currencies.js
+++ b/app/marketmaker/supported-currencies.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const coinlist = require('coinlist');
+
 const supportedCurrencies = [
 	{
 		coin: 'KMD',
@@ -150,4 +152,16 @@ const supportedCurrencies = [
 	},
 ];
 
-module.exports = supportedCurrencies;
+const getCurrencySymbols = () => supportedCurrencies.map(currency => currency.coin);
+
+const getCurrencyName = symbol => {
+	const coinParams = supportedCurrencies.find(currency => currency.coin === symbol);
+
+	return coinParams.name || coinlist.get(symbol, 'name') || symbol;
+};
+
+module.exports = {
+	supportedCurrencies,
+	getCurrencySymbols,
+	getCurrencyName,
+};

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -2,7 +2,7 @@ import util from 'util';
 import electron from 'electron';
 import {sha256} from 'crypto-hash';
 import PQueue from 'p-queue';
-import supportedCurrencies from '../marketmaker/supported-currencies';
+import {supportedCurrencies} from '../marketmaker/supported-currencies';
 import MarketmakerSocket from './marketmaker-socket';
 
 const getPort = electron.remote.require('get-port');

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -2,7 +2,7 @@ import util from 'util';
 import electron from 'electron';
 import {sha256} from 'crypto-hash';
 import PQueue from 'p-queue';
-import {supportedCurrencies} from '../marketmaker/supported-currencies';
+import {getCurrency} from '../marketmaker/supported-currencies';
 import MarketmakerSocket from './marketmaker-socket';
 
 const getPort = electron.remote.require('get-port');
@@ -79,15 +79,13 @@ export default class Api {
 	}
 
 	async enableCoinElectrum(coin) {
-		const servers = supportedCurrencies
-			.find(supportedCoin => supportedCoin.coin === coin)
-			.electrumServers;
+		const {electrumServers} = getCurrency(coin);
 
-		if (!servers) {
+		if (!electrumServers) {
 			throw new Error('Electrum mode not supported for this coin');
 		}
 
-		const requests = servers.map(server => this.request({
+		const requests = electrumServers.map(server => this.request({
 			method: 'electrum',
 			coin,
 			ipaddr: server.host,

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -6,7 +6,7 @@ import coinlist from 'coinlist';
 import roundTo from 'round-to';
 import {Container} from 'unstated';
 import {appViews} from '../../constants';
-import {supportedCurrencies} from '../../marketmaker/supported-currencies';
+import {supportedCurrencies, getCurrencyName} from '../../marketmaker/supported-currencies';
 import fireEvery from '../fire-every';
 import {formatCurrency, setLoginWindowBounds} from '../util';
 
@@ -99,7 +99,7 @@ class AppContainer extends Container {
 					const coinParams = supportedCurrencies.find(supportedCurrency => supportedCurrency.coin === currency.coin);
 
 					currency.symbol = currency.coin; // For readability
-					currency.name = coinParams.name || coinlist.get(currency.symbol, 'name') || currency.symbol;
+					currency.name = getCurrencyName(currency.symbol);
 					currency.cmcPercentChange24h = percentChange24h;
 
 					currency.balanceFormatted = roundTo(currency.balance, 8);

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -6,7 +6,7 @@ import coinlist from 'coinlist';
 import roundTo from 'round-to';
 import {Container} from 'unstated';
 import {appViews} from '../../constants';
-import {supportedCurrencies, getCurrencyName} from '../../marketmaker/supported-currencies';
+import {getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
 import fireEvery from '../fire-every';
 import {formatCurrency, setLoginWindowBounds} from '../util';
 
@@ -69,7 +69,7 @@ class AppContainer extends Container {
 		const FIVE_MINUTES = 1000 * 60 * 5;
 
 		await fireEvery(async () => {
-			this.coinPrices = await Promise.all(supportedCurrencies.map(currency => getTickerData(currency.coin)));
+			this.coinPrices = await Promise.all(getCurrencySymbols().map(getTickerData));
 		}, FIVE_MINUTES);
 	}
 

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -6,7 +6,7 @@ import coinlist from 'coinlist';
 import roundTo from 'round-to';
 import {Container} from 'unstated';
 import {appViews} from '../../constants';
-import supportedCurrencies from '../../marketmaker/supported-currencies';
+import {supportedCurrencies} from '../../marketmaker/supported-currencies';
 import fireEvery from '../fire-every';
 import {formatCurrency, setLoginWindowBounds} from '../util';
 

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -99,7 +99,7 @@ class AppContainer extends Container {
 					const coinParams = supportedCurrencies.find(supportedCurrency => supportedCurrency.coin === currency.coin);
 
 					currency.symbol = currency.coin; // For readability
-					currency.name = coinlist.get(currency.symbol, 'name') || coinParams.name || currency.symbol;
+					currency.name = coinParams.name || coinlist.get(currency.symbol, 'name') || currency.symbol;
 					currency.cmcPercentChange24h = percentChange24h;
 
 					currency.balanceFormatted = roundTo(currency.balance, 8);

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -96,8 +96,6 @@ class AppContainer extends Container {
 						currency.cmcBalanceUsd = currency.balance * currency.cmcPriceUsd;
 					}
 
-					const coinParams = supportedCurrencies.find(supportedCurrency => supportedCurrency.coin === currency.coin);
-
 					currency.symbol = currency.coin; // For readability
 					currency.name = getCurrencyName(currency.symbol);
 					currency.cmcPercentChange24h = percentChange24h;

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -96,8 +96,10 @@ class AppContainer extends Container {
 						currency.cmcBalanceUsd = currency.balance * currency.cmcPriceUsd;
 					}
 
+					const coinParams = supportedCurrencies.find(supportedCurrency => supportedCurrency.coin === currency.coin);
+
 					currency.symbol = currency.coin; // For readability
-					currency.name = coinlist.get(currency.symbol, 'name') || currency.symbol;
+					currency.name = coinlist.get(currency.symbol, 'name') || coinParams.name || currency.symbol;
 					currency.cmcPercentChange24h = percentChange24h;
 
 					currency.balanceFormatted = roundTo(currency.balance, 8);

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -28,7 +28,7 @@ class CurrencySelection extends React.Component {
 	};
 
 	render() {
-		const selectData = _.orderBy(getCurrencySymbols()).map(symbol => ({
+		const selectData = getCurrencySymbols().map(symbol => ({
 			label: `${getCurrencyName(symbol)} (${symbol})`,
 			value: symbol,
 			clearableValue: !['KMD', 'CHIPS'].includes(symbol),

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -7,7 +7,7 @@ import appContainer from 'containers/App';
 import Input from 'components/Input';
 import CurrencySelectOption from 'components/CurrencySelectOption';
 import Select from 'components/Select';
-import {supportedCurrencies, getCurrencyName} from '../../marketmaker/supported-currencies';
+import {supportedCurrencies, getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
 import TabView from './TabView';
 import './Preferences.scss';
 
@@ -29,10 +29,10 @@ class CurrencySelection extends React.Component {
 	};
 
 	render() {
-		const selectData = _.orderBy(supportedCurrencies, ['coin']).map(currency => ({
-			label: `${getCurrencyName(currency.coin)} (${currency.coin})`,
-			value: currency.coin,
-			clearableValue: !['KMD', 'CHIPS'].includes(currency.coin),
+		const selectData = _.orderBy(getCurrencySymbols()).map(symbol => ({
+			label: `${getCurrencyName(symbol)} (${symbol})`,
+			value: symbol,
+			clearableValue: !['KMD', 'CHIPS'].includes(symbol),
 		}));
 
 		return (

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -7,7 +7,7 @@ import appContainer from 'containers/App';
 import Input from 'components/Input';
 import CurrencySelectOption from 'components/CurrencySelectOption';
 import Select from 'components/Select';
-import {supportedCurrencies} from '../../marketmaker/supported-currencies';
+import {supportedCurrencies, getCurrencyName} from '../../marketmaker/supported-currencies';
 import TabView from './TabView';
 import './Preferences.scss';
 
@@ -30,7 +30,7 @@ class CurrencySelection extends React.Component {
 
 	render() {
 		const selectData = _.orderBy(supportedCurrencies, ['coin']).map(currency => ({
-			label: `${coinlist.get(currency.coin, 'name') || currency.coin} (${currency.coin})`,
+			label: `${getCurrencyName(currency.coin)} (${currency.coin})`,
 			value: currency.coin,
 			clearableValue: !['KMD', 'CHIPS'].includes(currency.coin),
 		}));

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -7,7 +7,7 @@ import appContainer from 'containers/App';
 import Input from 'components/Input';
 import CurrencySelectOption from 'components/CurrencySelectOption';
 import Select from 'components/Select';
-import supportedCurrencies from '../../marketmaker/supported-currencies';
+import {supportedCurrencies} from '../../marketmaker/supported-currencies';
 import TabView from './TabView';
 import './Preferences.scss';
 

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -1,13 +1,12 @@
 import electron from 'electron';
 import React from 'react';
 import _ from 'lodash';
-import coinlist from 'coinlist';
 import {Subscribe} from 'unstated';
 import appContainer from 'containers/App';
 import Input from 'components/Input';
 import CurrencySelectOption from 'components/CurrencySelectOption';
 import Select from 'components/Select';
-import {supportedCurrencies, getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
+import {getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
 import TabView from './TabView';
 import './Preferences.scss';
 


### PR DESCRIPTION
This is useful for setting custom names for currencies that aren't listed on CMC like Komodo asset chains or smaller crypto currencies.