### PR TITLE
Improve text size for large resolutions

### DIFF
--- a/app/renderer/views/Exchange/Exchange.scss
+++ b/app/renderer/views/Exchange/Exchange.scss
@@ -42,4 +42,8 @@
 		background-color: var(--widget-background-color);
 		border-radius: 4px;
 	}
+
+	@media (min-width: 1360px) {
+		grid-template-columns: 320px 1fr 320px;
+	}
 }

--- a/app/renderer/views/Exchange/Exchange.scss
+++ b/app/renderer/views/Exchange/Exchange.scss
@@ -43,7 +43,7 @@
 		border-radius: 4px;
 	}
 
-	@media (min-width: 1360px) {
+	@media (min-width: 1400px) {
 		grid-template-columns: 320px 1fr 320px;
 	}
 }

--- a/app/renderer/views/Exchange/Order.scss
+++ b/app/renderer/views/Exchange/Order.scss
@@ -127,6 +127,28 @@
 			margin-top: 28px;
 		}
 	}
+
+	@media (min-width: 1360px) {
+		.top .address {
+			font-size: 12px;
+		}
+
+		.center .table-wrapper {
+			font-size: 13px;
+
+			thead tr:first-child th {
+				font-size: 13px;
+			}
+		}
+
+		.bottom .form-section .status-message {
+			font-size: 13px;
+		}
+
+		.bottom .form-section label {
+			font-size: 14px;
+		}
+	}
 }
 
 .Exchange--Buy {

--- a/app/renderer/views/Exchange/Order.scss
+++ b/app/renderer/views/Exchange/Order.scss
@@ -44,7 +44,7 @@
 			left: 0;
 			overflow-x: hidden;
 			overflow-y: auto;
-			font-size: 11px;
+			font-size: 12px;
 			color: var(--text-color);
 			cursor: default;
 
@@ -119,7 +119,7 @@
 				bottom: -10px;
 				margin: 0;
 				padding: 0;
-				font-size: 11px;
+				font-size: 12px;
 			}
 		}
 
@@ -128,7 +128,7 @@
 		}
 	}
 
-	@media (min-width: 1360px) {
+	@media (min-width: 1400px) {
 		.top .address {
 			font-size: 12px;
 		}

--- a/app/renderer/views/Exchange/Swaps.scss
+++ b/app/renderer/views/Exchange/Swaps.scss
@@ -231,4 +231,11 @@
 			}
 		}
 	}
+
+	@media (min-width: 1360px) {
+		main .SwapList,
+		main .SwapList button {
+			font-size: 14px;
+		}
+	}
 }

--- a/app/renderer/views/Exchange/Swaps.scss
+++ b/app/renderer/views/Exchange/Swaps.scss
@@ -232,10 +232,10 @@
 		}
 	}
 
-	@media (min-width: 1360px) {
+	@media (min-width: 1400px) {
 		main .SwapList,
 		main .SwapList button {
-			font-size: 14px;
+			font-size: 13px;
 		}
 	}
 }

--- a/app/renderer/views/Trades.scss
+++ b/app/renderer/views/Trades.scss
@@ -26,7 +26,7 @@
 
 			td {
 				padding: 12px 5px 12px 0;
-				font-size: 13px;
+				font-size: 14px;
 			}
 
 			.view,


### PR DESCRIPTION
Fixes #176
Fixes lukechilds/hyperdex-bugtracker#4

When the window is 1360px or wider, the order columns are made bigger and some of the smaller text in the Exchange view is made larger.