### PR TITLE
Fix depth chart

### DIFF
--- a/app/renderer/components/DepthChart.js
+++ b/app/renderer/components/DepthChart.js
@@ -36,10 +36,10 @@ const DepthChart = props => {
 		asks = [{price: 0, depth: 0}];
 	}
 
+	bids = _.orderBy(bids, ['depth'], ['desc']);
+	asks = _.orderBy(asks, ['depth'], ['asc']);
 	bids = roundPrice(bids);
 	asks = roundPrice(asks);
-	bids = _.sortBy(bids, ['price']);
-	asks = _.sortBy(asks, ['price']);
 
 	return (
 		<div className="DepthChart">


### PR DESCRIPTION
It was previously sorted by price, which worked because the depth was according to price, now that we have more activity, this issue became more apparent. I also now order before rounding the price, so it correctly sorts very low numbers.
