### PR TITLE
Require user confirmation of transaction fees before withdrawal

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -215,7 +215,7 @@ export default class Api {
 		});
 
 		if (!result.complete) {
-			throw errorWithObject('Couldn\'t complete withdrawal', result);
+			throw errorWithObject('Couldn\'t create withdrawal transaction', result);
 		}
 
 		return {

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -224,10 +224,10 @@ export default class Api {
 		};
 	}
 
-	async broadcastTransaction(coin, transaction) {
+	async broadcastTransaction(currencySymbol, transaction) {
 		const response = await this.request({
 			method: 'sendrawtransaction',
-			coin,
+			coin: currencySymbol,
 			signedtx: transaction,
 		});
 

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -224,11 +224,11 @@ export default class Api {
 		};
 	}
 
-	async broadcastTransaction(currencySymbol, transaction) {
+	async broadcastTransaction(currencySymbol, rawTransaction) {
 		const response = await this.request({
 			method: 'sendrawtransaction',
 			coin: currencySymbol,
-			signedtx: transaction,
+			signedtx: rawTransaction,
 		});
 
 		if (!response.result === 'success') {
@@ -240,7 +240,7 @@ export default class Api {
 
 	async withdraw(opts) {
 		const {
-			hex: transaction,
+			hex: rawTransaction,
 			txfee: txFeeSatoshis,
 			txid,
 			amount,
@@ -253,7 +253,7 @@ export default class Api {
 
 		const broadcast = async () => {
 			// This is needed until a bug in marketmaker is resolved
-			await this.broadcastTransaction(opts.currency, transaction);
+			await this.broadcastTransaction(opts.currency, rawTransaction);
 
 			return {txid, amount, currency, address};
 		};

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -239,7 +239,7 @@ export default class Api {
 			txid,
 			amount,
 			currency,
-			address
+			address,
 		} = await this.createTransaction(opts);
 
 		// Convert from satoshis

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -249,7 +249,8 @@ export default class Api {
 		} = await this.createTransaction(opts);
 
 		// Convert from satoshis
-		const txFee = txFeeSatoshis / 100000000;
+		const SATOSHIS = 100000000;
+		const txFee = txFeeSatoshis / SATOSHIS;
 
 		const broadcast = async () => {
 			// This is needed until a bug in marketmaker is resolved

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -224,12 +224,18 @@ export default class Api {
 		};
 	}
 
-	broadcastTransaction(coin, transaction) {
-		return this.request({
+	async broadcastTransaction(coin, transaction) {
+		const response = await this.request({
 			method: 'sendrawtransaction',
 			coin,
 			signedtx: transaction,
 		});
+
+		if (!response.result === 'success') {
+			throw errorWithObject('Couldn\'t broadcast transaction', response);
+		}
+
+		return response.txid;
 	}
 
 	async withdraw(opts) {
@@ -247,9 +253,7 @@ export default class Api {
 
 		const broadcast = async () => {
 			// This is needed until a bug in marketmaker is resolved
-			try {
-				await this.broadcastTransaction(opts.currency, transaction);
-			} catch (_) {}
+			await this.broadcastTransaction(opts.currency, transaction);
 
 			return {txid, amount, currency, address};
 		};

--- a/app/renderer/views/Dashboard/WithdrawModal.js
+++ b/app/renderer/views/Dashboard/WithdrawModal.js
@@ -65,9 +65,8 @@ class WithdrawModal extends React.Component {
 
 	render() {
 		const currencyInfo = dashboardContainer.activeCurrency;
-		const networkFee = 0; // TODO: Implement getting the network fees
-		const maxAmount = currencyInfo.balance - networkFee;
-		const remainingBalance = roundTo(maxAmount - this.state.amount, 8);
+		const maxAmount = currencyInfo.balance;
+		const remainingBalance = roundTo(maxAmount - (this.state.amount + this.state.txFee), 8);
 		const setAmount = amount => {
 			/// this.setState({amount});
 			// Workaround for:

--- a/app/renderer/views/Dashboard/WithdrawModal.scss
+++ b/app/renderer/views/Dashboard/WithdrawModal.scss
@@ -37,6 +37,11 @@
 	.info {
 		display: flex;
 		justify-content: space-between;
+		transition: opacity 0.2s ease-in;
+
+		&.hidden {
+			opacity: 0;
+		}
 
 		span {
 			font-size: 14px;
@@ -52,7 +57,8 @@
 		}
 	}
 
-	.withdraw-button {
+	.withdraw-button,
+	.confirm-button {
 		align-self: center;
 		width: 176px;
 		margin-top: 30px;


### PR DESCRIPTION
Resolves #104 

Creates a raw transaction and requests the user to confirm they're happy with the network fee before broadcasting it.

<img width="431" src="https://user-images.githubusercontent.com/2123375/40297020-8636efb8-5d08-11e8-8140-b3d1f3afd3b8.gif" />

This uses a custom build of mm so can't be merged yet. We should have a release from Artem soon containing the fixes we need.