### PR TITLE
Add getCurrencyPrice(symbol) for checking supported currency prices

### DIFF
--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -105,11 +105,13 @@ class AppContainer extends Container {
 
 				// Mixin useful data for the currencies
 				currencies = currencies.map(currency => {
-					const {price, percentChange24h} = this.coinPrices.find(x => x.symbol === currency.coin);
+					currency.symbol = currency.coin; // For readability
 
-					if (price) {
-						currency.cmcPriceUsd = price;
-						currency.cmcBalanceUsd = currency.balance * price;
+					const {cmcPriceUsd, cmcPercentChange24h} = this.getCurrencyPrice(currency.symbol);
+
+					if (cmcPriceUsd) {
+						currency.cmcPriceUsd = cmcPriceUsd;
+						currency.cmcBalanceUsd = currency.balance * cmcPriceUsd;
 					} else {
 						// We handle coins not on CMC
 						// `currency.price` is the price of the coin in KMD
@@ -117,9 +119,8 @@ class AppContainer extends Container {
 						currency.cmcBalanceUsd = currency.balance * currency.cmcPriceUsd;
 					}
 
-					currency.symbol = currency.coin; // For readability
 					currency.name = getCurrencyName(currency.symbol);
-					currency.cmcPercentChange24h = percentChange24h;
+					currency.cmcPercentChange24h = cmcPercentChange24h;
 
 					currency.balanceFormatted = roundTo(currency.balance, 8);
 					currency.cmcPriceUsdFormatted = formatCurrency(currency.cmcPriceUsd);
@@ -139,6 +140,15 @@ class AppContainer extends Container {
 
 	getCurrency(symbol) {
 		return this.state.currencies.find(x => x.coin === symbol);
+	}
+
+	getCurrencyPrice(symbol) {
+		const {price, percentChange24h} = this.coinPrices.find(x => x.symbol === symbol);
+
+		return {
+			cmcPriceUsd: price,
+			cmcPercentChange24h: percentChange24h,
+		};
 	}
 
 	enableCoin(coin) {

--- a/app/renderer/views/Dashboard/Activity.js
+++ b/app/renderer/views/Dashboard/Activity.js
@@ -12,7 +12,7 @@ const Empty = () => (
 );
 
 const ActivityItem = ({swap}) => {
-	const {cmcPriceUsd} = appContainer.getCurrency(swap.baseCurrency);
+	const {cmcPriceUsd} = appContainer.getCurrencyPrice(swap.baseCurrency);
 	const totalUsd = swap.broadcast.baseCurrencyAmount * cmcPriceUsd;
 
 	return (

--- a/app/renderer/views/Dashboard/WalletActivity.js
+++ b/app/renderer/views/Dashboard/WalletActivity.js
@@ -16,7 +16,7 @@ const Empty = () => (
 );
 
 const ActivityItem = ({swap}) => {
-	const {cmcPriceUsd} = appContainer.getCurrency(swap.baseCurrency);
+	const {cmcPriceUsd} = appContainer.getCurrencyPrice(swap.baseCurrency);
 	const totalUsd = swap.broadcast.baseCurrencyAmount * cmcPriceUsd;
 
 	return (


### PR DESCRIPTION
We are currently only looking up the enabled currency prices in a lot of places. This causes issues if you disable a currency you have swap data for. Errors will be thrown when we try to lookup the price for the now disabled currency.

This PR gives a public method to check the fiat price of any supported currency, whether it's enabled or not. Using this method will still show the price for swap data on disabled currencies.

It's worth noting, if we ever remove a currency in the future we'll ecounter this issue again. Swap history for future unsupported currencies will break.