### PR TITLE
Tweak date formats

### DIFF
--- a/app/renderer/components/TimeSeriesChart.js
+++ b/app/renderer/components/TimeSeriesChart.js
@@ -17,7 +17,7 @@ const CustomTooltip = ({payload}) => {
 };
 
 const resolutionToLabelFormat = new Map([
-	['hour', 'HH:mm:ss'],
+	['hour', 'HH:mm'],
 	['day', 'HH:mm dddd'],
 	['week', 'dddd DD/MM'],
 	['month', 'DD/MM'],

--- a/app/renderer/components/TimeSeriesChart.js
+++ b/app/renderer/components/TimeSeriesChart.js
@@ -18,9 +18,9 @@ const CustomTooltip = ({payload}) => {
 
 const resolutionToLabelFormat = new Map([
 	['hour', 'HH:mm:ss'],
-	['day', 'HH:mm DD.MM'],
-	['week', 'dddd DD.MM'],
-	['month', 'DD.MM'],
+	['day', 'HH:mm dddd'],
+	['week', 'dddd DD/MM'],
+	['month', 'DD/MM'],
 	['year', 'MMMM'],
 	['all', 'MMMM YYYY'],
 ]);

--- a/app/renderer/views/Dashboard/Activity.js
+++ b/app/renderer/views/Dashboard/Activity.js
@@ -20,7 +20,7 @@ const ActivityItem = ({swap}) => {
 			<td className="timestamp">
 				<div>
 					<div>{formatDate(swap.timeStarted, 'HH:mm')}</div>
-					<div>{formatDate(swap.timeStarted, 'DD.MM.YY')}</div>
+					<div>{formatDate(swap.timeStarted, 'DD/MM/YY')}</div>
 				</div>
 			</td>
 			<td className="type">

--- a/app/renderer/views/Dashboard/WalletActivity.js
+++ b/app/renderer/views/Dashboard/WalletActivity.js
@@ -24,7 +24,7 @@ const ActivityItem = ({swap}) => {
 			<td className="timestamp">
 				<div>
 					<div>{formatDate(swap.timeStarted, 'HH:mm')}</div>
-					<div>{formatDate(swap.timeStarted, 'DD.MM.YY')}</div>
+					<div>{formatDate(swap.timeStarted, 'DD/MM/YY')}</div>
 				</div>
 			</td>
 			<td className="type">

--- a/app/renderer/views/Exchange/SwapDetails.js
+++ b/app/renderer/views/Exchange/SwapDetails.js
@@ -113,7 +113,7 @@ class SwapDetails extends React.Component {
 			<div className="modal-wrapper">
 				<Modal
 					className="SwapDetails"
-					title={`${baseCurrency}/${quoteCurrency} Swap \u{00A0}• \u{00A0}${formatDate(swap.timeStarted, 'HH:mm DD.MM.YY')}`}
+					title={`${baseCurrency}/${quoteCurrency} Swap \u{00A0}• \u{00A0}${formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}`}
 					icon="/assets/swap-icon.svg"
 					open={this.state.isOpen}
 					onClose={this.close}

--- a/app/renderer/views/Exchange/Swaps.js
+++ b/app/renderer/views/Exchange/Swaps.js
@@ -36,7 +36,7 @@ const Empty = () => (
 
 const SwapItem = ({swap}) => (
 	<div className="row">
-		<div className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD.MM')}</div>
+		<div className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}</div>
 		<div className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</div>
 		<div className="base-amount">+{swap.baseCurrencyAmount} {swap.baseCurrency}</div>
 		<div className="quote-amount">-{swap.quoteCurrencyAmount} {swap.quoteCurrency}</div>

--- a/app/renderer/views/Exchange/Swaps.scss
+++ b/app/renderer/views/Exchange/Swaps.scss
@@ -116,7 +116,7 @@
 			@media only screen and (min-width: 1260px) {
 				.row {
 					grid-template-areas: 'timestamp pairs base-amount quote-amount status view';
-					grid-template-columns: 11% 18% 22% 22%;
+					grid-template-columns: 16% 14% 23% 20%;
 					justify-content: unset;
 					white-space: unset;
 

--- a/app/renderer/views/Trades.js
+++ b/app/renderer/views/Trades.js
@@ -75,7 +75,7 @@ class CancelButton extends React.Component {
 // TODO(sindresorhus): Consider DRYing this up with the code in `Exchange.js`
 const SwapItem = ({swap}) => (
 	<tr>
-		<td className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD.MM.YY')}</td>
+		<td className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}</td>
 		<td className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</td>
 		<td className="base-amount">+{swap.baseCurrencyAmount} {swap.baseCurrency}</td>
 		<td className="quote-amount">-{swap.quoteCurrencyAmount} {swap.quoteCurrency}</td>


### PR DESCRIPTION
This prefers `dd/mm/yy` over `dd.mm.yy` and some other small tweaks.

Also this slightly improves the spacing of the swap data. Previously 4 digit swap values with 8 decimals would overflow larger ticker symbols.

Before:

<img width="560" alt="screen shot 2018-05-21 at 9 52 00 pm" src="https://user-images.githubusercontent.com/2123375/40313954-3e2386c6-5d41-11e8-86dc-9ed59b706b35.png">

After:

<img width="560" alt="screen shot 2018-05-21 at 9 48 07 pm" src="https://user-images.githubusercontent.com/2123375/40313850-f954e8dc-5d40-11e8-89bd-832ffe19ae9b.png">
