### PR TITLE
Hide and ignore "Custom Marketmaker" preference

### DIFF
--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -12,7 +12,9 @@ const config = remote.require('./config');
 const {getPortfolios, decryptSeedPhrase} = remote.require('./portfolio-util');
 
 const initApi = async seedPhrase => {
-	let url = config.get('marketmakerUrl');
+	// TODO: Disabled for now until we can properly support custom marketmaker instances
+	/// let url = config.get('marketmakerUrl');
+	let url = false;
 	if (url) {
 		console.log('Using custom marketmaker URL:', url);
 	} else {

--- a/app/renderer/views/Preferences.js
+++ b/app/renderer/views/Preferences.js
@@ -3,7 +3,6 @@ import React from 'react';
 import _ from 'lodash';
 import {Subscribe} from 'unstated';
 import appContainer from 'containers/App';
-import Input from 'components/Input';
 import CurrencySelectOption from 'components/CurrencySelectOption';
 import Select from 'components/Select';
 import {getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
@@ -60,7 +59,7 @@ class CurrencySelection extends React.Component {
 
 class Form extends React.Component {
 	state = {
-		marketmakerUrl: config.get('marketmakerUrl') || '',
+		/// marketmakerUrl: config.get('marketmakerUrl') || '',
 	};
 
 	persistState = _.debounce((name, value) => {
@@ -76,7 +75,7 @@ class Form extends React.Component {
 	render() {
 		return (
 			<React.Fragment>
-				<div className="form-group">
+				{/* <div className="form-group">
 					<label htmlFor="marketmakerUrl">
 						Custom Marketmaker URL: <small>(Requires app restart)</small>
 					</label>
@@ -86,7 +85,7 @@ class Form extends React.Component {
 						onChange={this.handleChange}
 						placeholder="Example: http://localhost:7783"
 					/>
-				</div>
+				</div> */}
 				<CurrencySelection/>
 			</React.Fragment>
 		);


### PR DESCRIPTION
- It works but doesn't correctly update the GUI and swaps (reported on Slack).
- We don't properly handle errors during login for it.
- We don't validate the contents, so users can just input anything there (fixes #259).
- It should be in the logged out preferences, which we don't have yet.
- The Marketmaker version has to be the exact same as the one we're using, which is unfeasible as it changes all the time.

So we should hide this until we can do it properly.