### PR TITLE
Package run script improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
 	"scripts": {
 		"postinstall": "electron-builder install-app-deps",
 		"lint": "xo && stylelint 'app/renderer/**/*.scss'",
-		"test": "npm run lint",
-		"start": "webpack && electron app",
-		"dev:watch": "webpack-dev-server --hot",
-		"dev:start": "delay 1 && electron app",
-		"dev": "yarn && run-p dev:*",
+		"test": "yarn lint",
+		"start:watch": "webpack-dev-server --hot",
+		"start:launch": "wait-for-localhost 8080 && electron app",
+		"start": "yarn && run-p start:*",
 		"pack": "webpack && electron-builder --dir",
 		"dist": "webpack --mode=production && electron-builder --mac --linux --win",
 		"release": "cd app && np --no-publish"
@@ -71,6 +70,7 @@
 		"style-loader": "^0.21.0",
 		"stylelint": "^9.2.0",
 		"stylelint-config-xo-scss": "^0.5.0",
+		"wait-for-localhost": "^1.0.0",
 		"webpack": "^4.8.1",
 		"webpack-cli": "^2.1.3",
 		"webpack-dev-server": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10063,6 +10063,12 @@ vuvuzela@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/vuvuzela/-/vuvuzela-1.0.3.tgz#3be145e58271c73ca55279dd851f12a682114b0b"
 
+wait-for-localhost@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wait-for-localhost/-/wait-for-localhost-1.0.0.tgz#940b0e5447b28a01ddf41f39a5d5ede02bf83603"
+  dependencies:
+    meow "^5.0.0"
+
 watchpack@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"


### PR DESCRIPTION
- We now use `yarn start` instead of `yarn dev`. No reason to have both.
- I fixed the issue where the app would launch blank. The fix is to actually wait for the dev server to become ready before launching Electron.