### PR TITLE
Fix stopping marketmaker on logout

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -288,12 +288,10 @@ export default class Api {
 	}
 
 	async stop() {
+		this.queue.clear();
+		await this.request({method: 'stop'});
 		this.queue.pause();
 		this.queue.clear();
-
-		try {
-			await this.request({method: 'stop'});
-		} catch (_) {} // Ignoring the error as `marketmaker` doesn't return a response
 	}
 
 	subscribeToSwap(swap) {

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -189,10 +189,10 @@ class AppContainer extends Container {
 	}
 
 	async logOut() {
-		this.stopMarketmaker();
+		await this.stopMarketmaker();
 		config.set('windowState', remote.getCurrentWindow().getBounds());
 		this.setActiveView('');
-		await Promise.resolve();
+		await Promise.resolve(); // Ensure the window is blank before changing the size
 		setLoginWindowBounds();
 		location.reload();
 	}


### PR DESCRIPTION
When fixing an issue a long time ago (https://github.com/lukechilds/hyperdex/commit/dfda2d944380691b287ab82f0348eb385d556df8), I introduced a bug. The fix then was to pause the queue so we wouldn't get any zombie calls after logging out. The problem is that the API `stop` command also uses the queue, so it was never run. We now only pause the queue after the `stop` command is done.