### PR TITLE
Rewrite `<Input>` and `<TextArea>` components to be fully controlled

### DIFF
--- a/app/renderer/components/Input.js
+++ b/app/renderer/components/Input.js
@@ -2,85 +2,114 @@ import React from 'react';
 import {classNames} from 'react-extras';
 import './Input.scss';
 
-const Input = ({
-	className,
-	level,
-	message,
-	errorMessage,
-	disabled,
-	readOnly,
-	onChange,
-	type = 'text',
-	icon,
-	iconSize,
-	iconName,
-	view: View,
-	button: Button,
-	...props
-}, ref) => {
-	if (errorMessage) {
-		level = 'error';
-		message = errorMessage;
+class Input extends React.Component {
+	state = {
+		value: this.props.value,
+	};
+
+	handleChange = event => {
+		const {value} = event.target;
+		const {onChange} = this.props;
+
+		if (onChange) {
+			event.persist();
+		}
+
+		this.setState({value}, () => {
+			if (onChange) {
+				onChange(value, event);
+			}
+		});
+	};
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.value !== this.state.value) {
+			this.setState({value: nextProps.value});
+		}
 	}
 
-	if (type === 'password') {
-		iconName = 'password';
-	}
+	render() {
+		let {
+			forwardedRef,
+			className,
+			level,
+			message,
+			errorMessage,
+			disabled,
+			readOnly,
+			onChange,
+			type = 'text',
+			icon,
+			iconSize,
+			iconName,
+			view: View,
+			button: Button,
+			...props
+		} = this.props;
 
-	if (iconName) {
-		icon = `/assets/${iconName}-icon.svg`;
-	}
+		if (errorMessage) {
+			level = 'error';
+			message = errorMessage;
+		}
 
-	const containerClassName = classNames(
-		'Input',
-		{
-			[`Input--${level}`]: level,
-			'Input--disabled': disabled,
-			'Input--readonly': readOnly,
-			'Input--icon': icon,
-			'Input--view': View || Button,
-		},
-		className
-	);
+		if (type === 'password') {
+			iconName = 'password';
+		}
 
-	return (
-		<div className={containerClassName}>
-			<div className="Input-wrap">
-				<input
-					{...props}
-					ref={ref}
-					type={type}
-					disabled={disabled}
-					readOnly={readOnly}
-					onChange={event => {
-						if (onChange) {
-							onChange(event.target.value, event);
-						}
-					}}
-				/>
-				{icon &&
-					<span className="Input__icon">
-						<img src={icon} width={iconSize}/>
-					</span>
-				}
-				{View &&
-					<span className="Input__view">
-						<View/>
-					</span>
-				}
-				{Button &&
-					<span className="Input__view Input__button">
-						<Button/>
+		if (iconName) {
+			icon = `/assets/${iconName}-icon.svg`;
+		}
+
+		const containerClassName = classNames(
+			'Input',
+			{
+				[`Input--${level}`]: level,
+				'Input--disabled': disabled,
+				'Input--readonly': readOnly,
+				'Input--icon': icon,
+				'Input--view': View || Button,
+			},
+			className
+		);
+
+		return (
+			<div className={containerClassName}>
+				<div className="Input-wrap">
+					<input
+						{...props}
+						ref={forwardedRef}
+						value={this.state.value}
+						type={type}
+						disabled={disabled}
+						readOnly={readOnly}
+						onChange={this.handleChange}
+					/>
+					{icon &&
+						<span className="Input__icon">
+							<img src={icon} width={iconSize}/>
+						</span>
+					}
+					{View &&
+						<span className="Input__view">
+							<View/>
+						</span>
+					}
+					{Button &&
+						<span className="Input__view Input__button">
+							<Button/>
+						</span>
+					}
+				</div>
+				{((level && message) || message) &&
+					<span className="Input__text">
+						<p>{message}</p>
 					</span>
 				}
 			</div>
-			{((level && message) || message) &&
-				<span className="Input__text">
-					<p>{message}</p>
-				</span>
-			}
-		</div>
-	);
-};
+		);
+	}
+}
 
-export default React.forwardRef(Input);
+export default React.forwardRef((props, ref) => (
+	<Input {...props} forwardedRef={ref}/>
+));

--- a/app/renderer/components/TextArea.js
+++ b/app/renderer/components/TextArea.js
@@ -2,64 +2,90 @@ import React from 'react';
 import {classNames} from 'react-extras';
 import './TextArea.scss';
 
-const TextArea = ({
-	className,
-	level,
-	message,
-	errorMessage,
-	disabled,
-	onChange,
-	preventNewlines,
-	...props
-}, ref) => {
-	if (errorMessage) {
-		level = 'error';
-		message = errorMessage;
+class TextArea extends React.Component {
+	state = {
+		value: this.props.value,
+	};
+
+	handleChange = event => {
+		const {target} = event;
+		const {value} = target;
+		const {onChange, preventNewlines} = this.props;
+
+		if (preventNewlines && /\r?\n/.test(value)) {
+			const form = target.closest('form');
+			if (form) {
+				form.dispatchEvent(new Event('submit'));
+			}
+
+			return;
+		}
+
+		if (onChange) {
+			event.persist();
+		}
+
+		this.setState({value}, () => {
+			if (onChange) {
+				onChange(value, event);
+			}
+		});
+	};
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.value !== this.state.value) {
+			this.setState({value: nextProps.value});
+		}
 	}
 
-	const containerClassName = classNames(
-		'TextArea',
-		'Input',
-		{
-			[`Input--${level}`]: level,
-			'Input--disabled': disabled,
-		},
-		className
-	);
+	render() {
+		let {
+			forwardedRef,
+			className,
+			level,
+			message,
+			errorMessage,
+			disabled,
+			preventNewlines,
+			...props
+		} = this.props;
 
-	return (
-		<div className={containerClassName}>
-			<div className="Input-wrap">
-				<textarea
-					{...props}
-					ref={ref}
-					disabled={disabled}
-					onChange={event => {
-						const {target} = event;
-						const {value} = target;
+		if (errorMessage) {
+			level = 'error';
+			message = errorMessage;
+		}
 
-						if (preventNewlines && /\r?\n/.test(value)) {
-							const form = target.closest('form');
-							if (form) {
-								form.dispatchEvent(new Event('submit'));
-							}
+		const containerClassName = classNames(
+			'TextArea',
+			'Input',
+			{
+				[`Input--${level}`]: level,
+				'Input--disabled': disabled,
+			},
+			className
+		);
 
-							return;
-						}
-
-						if (onChange) {
-							onChange(value);
-						}
-					}}
-				/>
+		return (
+			<div className={containerClassName}>
+				<div className="Input-wrap">
+					<textarea
+						{...props}
+						ref={forwardedRef}
+						value={this.state.value}
+						disabled={disabled}
+						onChange={this.handleChange}
+					/>
+				</div>
+				{((level && message) || message) &&
+					<span className="Input__text">
+						<p>{message}</p>
+					</span>
+				}
 			</div>
-			{((level && message) || message) &&
-				<span className="Input__text">
-					<p>{message}</p>
-				</span>
-			}
-		</div>
-	);
-};
+		);
+	}
+}
 
-export default React.forwardRef(TextArea);
+export default React.forwardRef((props, ref) => (
+	<TextArea {...props} forwardedRef={ref}/>
+));


### PR DESCRIPTION
Since our state updates are async, it creates a race condition where React cannot correctly diff the updates and it results in the cursor being pushed to the end.

See this React issue: https://github.com/facebook/react/issues/955 In short, just another React annoyance.

Fixes #237