### PR TITLE
Add `alwaysEnabledCurrencies` constant

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -23,3 +23,8 @@ exports.appViews = [
 	'Trades',
 	'Settings',
 ];
+
+exports.defaultCurrencies = [
+	'KMD',
+	'CHIPS',
+];

--- a/app/constants.js
+++ b/app/constants.js
@@ -24,7 +24,7 @@ exports.appViews = [
 	'Settings',
 ];
 
-exports.defaultCurrencies = [
+exports.alwaysEnabledCurrencies = [
 	'KMD',
 	'CHIPS',
 ];

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -6,7 +6,7 @@ import Cycled from 'cycled';
 import coinlist from 'coinlist';
 import roundTo from 'round-to';
 import {Container} from 'unstated';
-import {appViews, defaultCurrencies} from '../../constants';
+import {appViews, alwaysEnabledCurrencies} from '../../constants';
 import {getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
 import fireEvery from '../fire-every';
 import {formatCurrency, setLoginWindowBounds} from '../util';
@@ -60,7 +60,7 @@ const getTickerData = async symbol => {
 class AppContainer extends Container {
 	state = {
 		activeView: 'Login',
-		enabledCoins: _.union(defaultCurrencies, config.get('enabledCoins')),
+		enabledCoins: _.union(alwaysEnabledCurrencies, config.get('enabledCoins')),
 		currencies: [],
 	};
 

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -60,7 +60,7 @@ const getTickerData = async symbol => {
 class AppContainer extends Container {
 	state = {
 		activeView: 'Login',
-		enabledCoins: [...defaultCurrencies, ...config.get('enabledCoins')],
+		enabledCoins: _.union(defaultCurrencies, config.get('enabledCoins')),
 		currencies: [],
 	};
 

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -6,7 +6,7 @@ import Cycled from 'cycled';
 import coinlist from 'coinlist';
 import roundTo from 'round-to';
 import {Container} from 'unstated';
-import {appViews} from '../../constants';
+import {appViews, defaultCurrencies} from '../../constants';
 import {getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
 import fireEvery from '../fire-every';
 import {formatCurrency, setLoginWindowBounds} from '../util';
@@ -60,7 +60,7 @@ const getTickerData = async symbol => {
 class AppContainer extends Container {
 	state = {
 		activeView: 'Login',
-		enabledCoins: config.get('enabledCoins'),
+		enabledCoins: [...defaultCurrencies, ...config.get('enabledCoins')],
 		currencies: [],
 	};
 

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -2,7 +2,7 @@ import {remote} from 'electron';
 import {setWindowBounds} from 'electron-util';
 import ipc from 'electron-better-ipc';
 import {Container} from 'unstated';
-import {minWindowSize, alwaysEnabledCurrencies} from '../../constants';
+import {minWindowSize} from '../../constants';
 import {isDevelopment} from '../../util-common';
 import Api from '../api';
 import SwapDB from '../swap-db';

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -92,7 +92,6 @@ class LoginContainer extends Container {
 			window._swapDB = swapDB;
 		}
 
-		await Promise.all(alwaysEnabledCurrencies.map(x => api.enableCurrency(x)));
 		await Promise.all(appContainer.state.enabledCoins.map(x => api.enableCurrency(x)));
 
 		await appContainer.watchCMC();

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -2,7 +2,7 @@ import {remote} from 'electron';
 import {setWindowBounds} from 'electron-util';
 import ipc from 'electron-better-ipc';
 import {Container} from 'unstated';
-import {minWindowSize} from '../../constants';
+import {minWindowSize, defaultCurrencies} from '../../constants';
 import {isDevelopment} from '../../util-common';
 import Api from '../api';
 import SwapDB from '../swap-db';
@@ -92,6 +92,7 @@ class LoginContainer extends Container {
 			window._swapDB = swapDB;
 		}
 
+		await Promise.all(defaultCurrencies.map(x => api.enableCoin(x)));
 		await Promise.all(appContainer.state.enabledCoins.map(x => api.enableCoin(x)));
 
 		await appContainer.watchCMC();

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -2,7 +2,7 @@ import {remote} from 'electron';
 import {setWindowBounds} from 'electron-util';
 import ipc from 'electron-better-ipc';
 import {Container} from 'unstated';
-import {minWindowSize, defaultCurrencies} from '../../constants';
+import {minWindowSize, alwaysEnabledCurrencies} from '../../constants';
 import {isDevelopment} from '../../util-common';
 import Api from '../api';
 import SwapDB from '../swap-db';
@@ -92,7 +92,7 @@ class LoginContainer extends Container {
 			window._swapDB = swapDB;
 		}
 
-		await Promise.all(defaultCurrencies.map(x => api.enableCoin(x)));
+		await Promise.all(alwaysEnabledCurrencies.map(x => api.enableCoin(x)));
 		await Promise.all(appContainer.state.enabledCoins.map(x => api.enableCoin(x)));
 
 		await appContainer.watchCMC();

--- a/app/renderer/views/Settings.js
+++ b/app/renderer/views/Settings.js
@@ -8,6 +8,7 @@ import CurrencySelectOption from 'components/CurrencySelectOption';
 import Select from 'components/Select';
 import {getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
 import {isDevelopment} from '../../util-common';
+import {defaultCurrencies} from '../../constants';
 import TabView from './TabView';
 import './Settings.scss';
 
@@ -35,7 +36,7 @@ class CurrencySelection extends React.Component {
 		const selectData = currencySymbols.map(symbol => ({
 			label: `${getCurrencyName(symbol)} (${symbol})`,
 			value: symbol,
-			clearableValue: !['KMD', 'CHIPS'].includes(symbol),
+			clearableValue: !defaultCurrencies.includes(symbol),
 		}));
 
 		return (

--- a/app/renderer/views/Settings.js
+++ b/app/renderer/views/Settings.js
@@ -8,7 +8,7 @@ import CurrencySelectOption from 'components/CurrencySelectOption';
 import Select from 'components/Select';
 import {getCurrencySymbols, getCurrencyName} from '../../marketmaker/supported-currencies';
 import {isDevelopment} from '../../util-common';
-import {defaultCurrencies} from '../../constants';
+import {alwaysEnabledCurrencies} from '../../constants';
 import TabView from './TabView';
 import './Settings.scss';
 
@@ -36,7 +36,7 @@ class CurrencySelection extends React.Component {
 		const selectData = currencySymbols.map(symbol => ({
 			label: `${getCurrencyName(symbol)} (${symbol})`,
 			value: symbol,
-			clearableValue: !defaultCurrencies.includes(symbol),
+			clearableValue: !alwaysEnabledCurrencies.includes(symbol),
 		}));
 
 		return (


### PR DESCRIPTION
This is required for ETH/ERC20, that's not ready yet but this is still an improvement over the current code so I've cherry picked it out from my local ETH branch.

It's nice to have this defined somewhere rather than hardcode it in a few places.

This also ensures these currencies are always activated (even if they're removed from the config). That's good because it'll break things if KMD (and soon ETOMIC) aren't enabled.

This also means we can easily enforce new currencies in updates (like ETOMIC). Updating the default coins in the config won't work after the initial install.