### PR TITLE
Refactor `api.enableCoin()`

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -65,40 +65,28 @@ export default class Api {
 		return this.request({method: 'bot_list'});
 	}
 
-	async enableCoin(coin, opts = {}) {
-		if (!getCurrency(coin)) {
-			console.error('Tried to enable unsupported currency:', coin);
+	async enableCoin(symbol) {
+		const currency = getCurrency(symbol);
+
+		if (!currency) {
+			console.error('Tried to enable unsupported currency:', symbol);
 			return;
 		}
 
-		if (opts.isFullNode) {
-			const response = await this.enableCoinFullNode(coin);
-			return response.status === 'active';
+		if (currency.electrumServers) {
+			const requests = currency.electrumServers.map(server => this.request({
+				method: 'electrum',
+				coin: symbol,
+				ipaddr: server.host,
+				port: server.port,
+			}));
+
+			const responses = await Promise.all(requests);
+			return responses.filter(response => response.result === 'success') > 0;
 		}
 
-		const responses = await this.enableCoinElectrum(coin);
-		return responses.filter(response => response.result === 'success') > 0;
-	}
-
-	enableCoinFullNode(coin) {
-		return this.request({method: 'enable', coin});
-	}
-
-	async enableCoinElectrum(coin) {
-		const {electrumServers} = getCurrency(coin);
-
-		if (!electrumServers) {
-			throw new Error('Electrum mode not supported for this coin');
-		}
-
-		const requests = electrumServers.map(server => this.request({
-			method: 'electrum',
-			coin,
-			ipaddr: server.host,
-			port: server.port,
-		}));
-
-		return Promise.all(requests);
+		const response = await this.request({method: 'enable', coin: symbol});
+		return response.status === 'active';
 	}
 
 	disableCoin(coin) {

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -65,7 +65,7 @@ export default class Api {
 		return this.request({method: 'bot_list'});
 	}
 
-	async enableCoin(symbol) {
+	async enableCurrency(symbol) {
 		const currency = getCurrency(symbol);
 
 		if (!currency) {

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -173,9 +173,9 @@ class AppContainer extends Container {
 		};
 	}
 
-	enableCoin(coin) {
+	enableCurrency(coin) {
 		this.setState(prevState => {
-			this.api.enableCoin(coin);
+			this.api.enableCurrency(coin);
 			const enabledCoins = [...prevState.enabledCoins, coin];
 			config.set('enabledCoins', enabledCoins);
 			return {enabledCoins};

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -92,7 +92,7 @@ class LoginContainer extends Container {
 			window._swapDB = swapDB;
 		}
 
-		await Promise.all(appContainer.state.enabledCoins.map(x => api.enableCoin(x)));
+		await Promise.all(appContainer.state.enabledCoins.map(x => api.enableCurrency(x)));
 
 		await appContainer.watchCMC();
 		await appContainer.watchCurrencies();

--- a/app/renderer/views/Settings.js
+++ b/app/renderer/views/Settings.js
@@ -21,7 +21,7 @@ class CurrencySelection extends React.Component {
 		// We have to do our own diffing as `react-select` just returns the new `value` array
 		const [added] = _.difference(newCurrencies, enabledCurrencies);
 		if (added) {
-			appContainer.enableCoin(added);
+			appContainer.enableCurrency(added);
 		} else {
 			const [removed] = _.difference(enabledCurrencies, newCurrencies);
 			appContainer.disableCoin(removed);


### PR DESCRIPTION
This is required for ETH/ERC20, that's not ready yet but this is still an improvement over the current code so I've cherry picked it out from my local ETH branch.

This way is much neater, it just auto detects if we have Electrum servers for a given currency symbol. If we do it's enabled in Electrum mode, if not it falls back to full node. No need to manually specify which.

We will never actually use any currencies in full node mode but ETH/ERC20 tokens need to be enabled with the full node API, even though they connect to a light client.

Also updated all terminology `coin => currency`.
Also no longer expose different methods, it's just consolidated into a single `api.enableCurrency(symbol)` method.