### PR TITLE
Fix number inputs

### DIFF
--- a/app/renderer/components/Input.js
+++ b/app/renderer/components/Input.js
@@ -2,14 +2,33 @@ import React from 'react';
 import {classNames} from 'react-extras';
 import './Input.scss';
 
+const stripLeadingZeros = string => string.replace(/^0+(?=\d)/, '');
+
+const fractionCount = string => {
+	const match = /\d+\.(\d+)$/.exec(string);
+	return match ? match[1].length : 0;
+};
+
 class Input extends React.Component {
 	state = {
-		value: this.props.value,
+		value: this.props.value || '',
 	};
 
 	handleChange = event => {
-		const {value} = event.target;
-		const {onChange} = this.props;
+		let {value} = event.target;
+		const {onlyNumeric, onChange} = this.props;
+
+		if (onlyNumeric) {
+			if (Number.isNaN(Number(value))) {
+				return;
+			}
+
+			value = stripLeadingZeros(value);
+
+			if (this._shouldTruncateFractions(value)) {
+				return;
+			}
+		}
 
 		if (onChange) {
 			event.persist();
@@ -21,6 +40,32 @@ class Input extends React.Component {
 			}
 		});
 	};
+
+	_shouldTruncateFractions(value) {
+		const {fractionalDigits} = this.props;
+
+		if (typeof fractionalDigits === 'undefined') {
+			return value;
+		}
+
+		return value !== '' && !/^\d+\.0*$/.test(value) && fractionCount(value) > fractionalDigits;
+	}
+
+	_truncateZeroOnlyFractions(value) {
+		const {fractionalDigits} = this.props;
+
+		if (typeof fractionalDigits === 'undefined') {
+			return value;
+		}
+
+		// Special case for handling `0.00000000` with fractions longer than `fractionalDigits`
+		const [number, fraction] = (value || '').split('.');
+		if (/^0+$/.test(fraction) && fraction.length > fractionalDigits) {
+			value = `${number}.${'0'.repeat(fractionalDigits)}`;
+		}
+
+		return value;
+	}
 
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.value !== this.state.value) {
@@ -38,6 +83,8 @@ class Input extends React.Component {
 			disabled,
 			readOnly,
 			onChange,
+			onlyNumeric,
+			fractionalDigits,
 			type = 'text',
 			icon,
 			iconSize,
@@ -72,13 +119,24 @@ class Input extends React.Component {
 			className
 		);
 
+		let {value} = this.state;
+
+		if (typeof value !== 'string') {
+			throw new TypeError(`Expected \`value\` to be a string, got ${typeof value}`);
+		}
+
+		if (this._shouldTruncateFractions(value)) {
+			value = Number.parseFloat(value).toFixed(fractionalDigits);
+		}
+		value = this._truncateZeroOnlyFractions(value);
+
 		return (
 			<div className={containerClassName}>
 				<div className="Input-wrap">
 					<input
 						{...props}
 						ref={forwardedRef}
-						value={this.state.value}
+						value={value}
 						type={type}
 						disabled={disabled}
 						readOnly={readOnly}

--- a/app/renderer/components/Input.js
+++ b/app/renderer/components/Input.js
@@ -45,7 +45,7 @@ class Input extends React.Component {
 		const {fractionalDigits} = this.props;
 
 		if (typeof fractionalDigits === 'undefined') {
-			return value;
+			return false;
 		}
 
 		return value !== '' && !/^\d+\.0*$/.test(value) && fractionCount(value) > fractionalDigits;
@@ -125,10 +125,12 @@ class Input extends React.Component {
 			throw new TypeError(`Expected \`value\` to be a string, got ${typeof value}`);
 		}
 
-		if (this._shouldTruncateFractions(value)) {
-			value = Number.parseFloat(value).toFixed(fractionalDigits);
+		if (onlyNumeric) {
+			if (this._shouldTruncateFractions(value)) {
+				value = Number.parseFloat(value).toFixed(fractionalDigits);
+			}
+			value = this._truncateZeroOnlyFractions(value);
 		}
-		value = this._truncateZeroOnlyFractions(value);
 
 		return (
 			<div className={containerClassName}>

--- a/app/renderer/views/Dashboard/WithdrawModal.js
+++ b/app/renderer/views/Dashboard/WithdrawModal.js
@@ -12,7 +12,8 @@ import './WithdrawModal.scss';
 const getInitialProps = () => ({
 	isOpen: false,
 	recipientAddress: '',
-	amount: 0,
+	amount: '',
+	amountInUsd: '',
 	isWithdrawing: false,
 	isBroadcasting: false,
 	txFee: 0,
@@ -44,7 +45,7 @@ class WithdrawModal extends React.Component {
 		const {txFee, broadcast} = await appContainer.api.withdraw({
 			currency,
 			address,
-			amount,
+			amount: Number(amount),
 		});
 
 		this.setState({txFee, broadcast});
@@ -67,9 +68,13 @@ class WithdrawModal extends React.Component {
 	render() {
 		const currencyInfo = dashboardContainer.activeCurrency;
 		const maxAmount = currencyInfo.balance;
-		const remainingBalance = roundTo(maxAmount - (this.state.amount + this.state.txFee), 8);
-		const setAmount = amount => {
-			this.setState({amount});
+		const remainingBalance = roundTo(maxAmount - (Number(this.state.amount) + this.state.txFee), 8);
+
+		const setAmount = value => {
+			this.setState({
+				amount: value,
+				amountInUsd: String(Number.parseFloat(value || '0') / currencyInfo.cmcPriceUsd),
+			});
 		};
 
 		return (
@@ -84,8 +89,8 @@ class WithdrawModal extends React.Component {
 						<div className="section">
 							<label>Recipient:</label>
 							<Input
-								required
 								value={this.state.recipientAddress}
+								required
 								placeholder={`Enter ${currencyInfo.symbol} Address`}
 								disabled={this.state.isWithdrawing}
 								onChange={value => {
@@ -97,15 +102,13 @@ class WithdrawModal extends React.Component {
 							<label>Amount:</label>
 							<div className="amount-inputs">
 								<Input
-									value={roundTo(this.state.amount, 8)}
-									type="number"
-									min={0}
-									step="any"
+									value={this.state.amount}
 									required
+									onlyNumeric
+									fractionalDigits={8}
 									disabled={this.state.isWithdrawing}
 									onChange={value => {
-										const amount = Number.parseFloat(value || 0);
-										setAmount(amount);
+										setAmount(value);
 									}}
 									view={() => (
 										<span>{currencyInfo.symbol}</span>
@@ -113,15 +116,16 @@ class WithdrawModal extends React.Component {
 								/>
 								<span className="separator">≈</span>
 								<Input
-									value={roundTo(this.state.amount * currencyInfo.cmcPriceUsd, 2)}
-									type="number"
-									min={0}
-									step="any"
+									value={this.state.amountInUsd}
 									required
+									onlyNumeric
+									fractionalDigits={4}
 									disabled={this.state.isWithdrawing}
 									onChange={value => {
-										const amount = Number.parseFloat(value || 0) / currencyInfo.cmcPriceUsd;
-										setAmount(amount);
+										this.setState({
+											amountInUsd: value,
+											amount: String(Number.parseFloat(value || '0') * currencyInfo.cmcPriceUsd),
+										});
 									}}
 									view={() => (
 										<span>USD</span>

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -200,15 +200,36 @@ class Bottom extends React.Component {
 					<h3>{`${typeTitled} ${state.baseCurrency}`}</h3>
 					<div className="form-section">
 						<label>Price ({state.quoteCurrency}):</label>
-						<Input className="price-input" type="number" min="0" step="any" required value={this.props.price} onChange={this.props.handlePriceChange} button={TargetPriceButton}/>
+						<Input
+							className="price-input"
+							required
+							onlyNumeric
+							fractionalDigits={8}
+							value={this.props.price}
+							onChange={this.props.handlePriceChange}
+							button={TargetPriceButton}
+						/>
 					</div>
 					<div className="form-section">
 						<label>Amount ({state.baseCurrency}):</label>
-						<Input type="number" min="0" step="any" required value={this.props.amount} onChange={this.props.handleAmountChange} button={MaxPriceButton}/>
+						<Input
+							required
+							onlyNumeric
+							fractionalDigits={8}
+							value={this.props.amount}
+							onChange={this.props.handleAmountChange}
+							button={MaxPriceButton}
+						/>
 					</div>
 					<div className="form-section">
 						<label>Total ({state.quoteCurrency}):</label>
-						<Input type="number" min="0" step="any" required value={this.props.total} onChange={this.props.handleTotalChange}/>
+						<Input
+							required
+							onlyNumeric
+							fractionalDigits={8}
+							value={String(this.props.total)}
+							onChange={this.props.handleTotalChange}
+						/>
 					</div>
 					<div className="form-section">
 						{this.state.statusMessage &&
@@ -234,44 +255,38 @@ class Bottom extends React.Component {
 
 class Order extends React.Component {
 	state = {
-		price: 0,
-		amount: 0,
+		// We're using strings and not `input type="number"` because of a React issue:
+		// https://github.com/facebook/react/issues/9402
+		price: '',
+		amount: '',
 		total: 0,
 	};
 
 	handlePriceChange = price => {
-		// TODO: The `price`, `amount`, and `total` will will sometimes have leading 0s in the DOM
-		// even though we remove them in React state.
-		// This is a known React bug and should be fixed soon.
-		// https://github.com/facebook/react/issues/9402
-		price = (price === '') ? '' : roundTo(Number(price), 8);
 		this.setState(prevState => ({
 			price,
-			total: roundTo(price * prevState.amount, 8),
+			total: roundTo(Number(price) * Number(prevState.amount), 8),
 		}));
 
-		this.setState({price});
 		if (this.state.total > 0) {
 			this.handleTotalChange(this.state.total);
-		} else if (this.state.amount > 0) {
+		} else if (Number(this.state.amount) > 0) {
 			this.handleAmountChange(this.state.amount);
 		}
 	}
 
 	handleAmountChange = amount => {
-		amount = (amount === '') ? '' : roundTo(Number(amount), 8);
 		this.setState(prevState => ({
-			amount,
-			total: roundTo(prevState.price * amount, 8),
+			amount: String(amount),
+			total: roundTo(Number(prevState.price) * Number(amount), 8),
 		}));
 	}
 
 	handleTotalChange = total => {
-		total = (total === '') ? '' : roundTo(Number(total), 8);
 		this.setState(prevState => {
 			const newState = {total};
 			if (prevState.price > 0) {
-				newState.amount = roundTo(total / prevState.price, 8);
+				newState.amount = String(roundTo(total / prevState.price, 8));
 			}
 
 			return newState;


### PR DESCRIPTION
Basically, React is totally broken when it comes to number inputs. The fix is to just use normal string based inputs. I also added some validation for number inputs.

I also changed the withdraw modal to use separate states for the amount and the amount in USD. That's the only way to make it work.

tl;dr Numbers are hard