### PR TITLE
Correctly handle inverse values for sell orders

### DIFF
--- a/app/renderer/components/SwapDetails.js
+++ b/app/renderer/components/SwapDetails.js
@@ -19,6 +19,27 @@ const stageToTitle = new Map([
 	['alicespend', 'Alice Spend'],
 ]);
 
+const getOverview = swap => {
+	const isBuyOrder = swap.orderType === 'buy';
+	const overview = {
+		fromTitle: 'Exchanging:',
+		forTitle: 'For:',
+		fromCurrency: isBuyOrder ? swap.quoteCurrency : swap.baseCurrency,
+		forCurrency: isBuyOrder ? swap.baseCurrency : swap.quoteCurrency,
+		fromAmount: isBuyOrder ? swap.broadcast.quoteCurrencyAmount : swap.broadcast.baseCurrencyAmount,
+		forAmount: isBuyOrder ? swap.broadcast.baseCurrencyAmount : swap.broadcast.quoteCurrencyAmount,
+	};
+
+	if (swap.executed.quoteCurrencyAmount) {
+		overview.fromTitle = 'You exchanged:';
+		overview.forTitle = 'You received:';
+		overview.fromAmount = isBuyOrder ? swap.executed.quoteCurrencyAmount : swap.executed.baseCurrencyAmount;
+		overview.forAmount = isBuyOrder ? swap.executed.baseCurrencyAmount : swap.executed.quoteCurrencyAmount;
+	}
+
+	return overview;
+};
+
 class SwapDetails extends React.Component {
 	state = {
 		isOpen: false,
@@ -83,26 +104,7 @@ class SwapDetails extends React.Component {
 			);
 		});
 
-		const overviewData = (() => {
-			const isBuyOrder = swap.orderType === 'buy';
-			const overview = {
-				fromTitle: 'Exchanging:',
-				forTitle: 'For:',
-				fromCurrency: isBuyOrder ? quoteCurrency : baseCurrency,
-				forCurrency: isBuyOrder ? baseCurrency : quoteCurrency,
-				fromAmount: isBuyOrder ? swap.broadcast.quoteCurrencyAmount : swap.broadcast.baseCurrencyAmount,
-				forAmount: isBuyOrder ? swap.broadcast.baseCurrencyAmount : swap.broadcast.quoteCurrencyAmount,
-			};
-
-			if (swap.executed.quoteCurrencyAmount) {
-				overview.fromTitle = 'You exchanged:';
-				overview.forTitle = 'You received:';
-				overview.fromAmount = isBuyOrder ? swap.executed.quoteCurrencyAmount : swap.executed.baseCurrencyAmount;
-				overview.forAmount = isBuyOrder ? swap.executed.baseCurrencyAmount : swap.executed.quoteCurrencyAmount;
-			}
-
-			return overview;
-		})();
+		const overview = getOverview(swap);
 
 		return (
 			<div className="modal-wrapper">
@@ -117,15 +119,15 @@ class SwapDetails extends React.Component {
 					<React.Fragment>
 						<div className="section overview">
 							<div className="from">
-								<CurrencyIcon symbol={overviewData.fromCurrency}/>
-								<p>{overviewData.fromTitle}</p>
-								<p className="amount">{overviewData.fromAmount} {overviewData.fromCurrency}</p>
+								<CurrencyIcon symbol={overview.fromCurrency}/>
+								<p>{overview.fromTitle}</p>
+								<p className="amount">{overview.fromAmount} {overview.fromCurrency}</p>
 							</div>
 							<div className="arrow">→</div>
 							<div className="for">
-								<CurrencyIcon symbol={overviewData.forCurrency}/>
-								<p>{overviewData.forTitle}</p>
-								<p className="amount">{overviewData.forAmount} {overviewData.forCurrency}</p>
+								<CurrencyIcon symbol={overview.forCurrency}/>
+								<p>{overview.forTitle}</p>
+								<p className="amount">{overview.forAmount} {overview.forCurrency}</p>
 							</div>
 						</div>
 						<div className="section progress">

--- a/app/renderer/components/SwapDetails.js
+++ b/app/renderer/components/SwapDetails.js
@@ -73,7 +73,7 @@ class SwapDetails extends React.Component {
 				<div key={value}>
 					<h6>{title(value)}</h6>
 					<p>
-						<span className="label">Buy:</span> {zeroPadFraction(swap[value].baseCurrencyAmount)} {baseCurrency}
+						<span className="label">{swap.isSellOrder ? 'Sell' : 'Buy'}:</span> {zeroPadFraction(swap[value].baseCurrencyAmount)} {baseCurrency}
 						<br/>
 						<span className="label">For:</span> {zeroPadFraction(swap[value].quoteCurrencyAmount)} {quoteCurrency}
 						<br/>
@@ -84,29 +84,20 @@ class SwapDetails extends React.Component {
 		});
 
 		const overviewData = (() => {
-			let overview = {
-				quoteTitle: 'Requesting:',
-				baseTitle: 'For:',
-				quoteAmount: swap.requested.quoteCurrencyAmount,
-				baseAmount: swap.requested.baseCurrencyAmount,
+			const overview = {
+				fromTitle: 'Exchanging:',
+				forTitle: 'For:',
+				fromCurrency: swap.isSellOrder ? baseCurrency : quoteCurrency,
+				forCurrency: swap.isSellOrder ? quoteCurrency : baseCurrency,
+				fromAmount: swap.isSellOrder ? swap.broadcast.baseCurrencyAmount : swap.broadcast.quoteCurrencyAmount,
+				forAmount: swap.isSellOrder ? swap.broadcast.quoteCurrencyAmount : swap.broadcast.baseCurrencyAmount,
 			};
 
-			if (swap.broadcast.quoteCurrencyAmount) {
-				overview = {
-					quoteTitle: 'Exchanging:',
-					baseTitle: 'For:',
-					quoteAmount: swap.broadcast.quoteCurrencyAmount,
-					baseAmount: swap.broadcast.baseCurrencyAmount,
-				};
-			}
-
 			if (swap.executed.quoteCurrencyAmount) {
-				overview = {
-					quoteTitle: 'You exchanged:',
-					baseTitle: 'You received:',
-					quoteAmount: swap.executed.quoteCurrencyAmount,
-					baseAmount: swap.executed.baseCurrencyAmount,
-				};
+				overview.fromTitle = 'You exchanged:';
+				overview.forTitle = 'You received:';
+				overview.fromAmount = swap.isSellOrder ? swap.executed.baseCurrencyAmount : swap.executed.quoteCurrencyAmount;
+				overview.forAmount = swap.isSellOrder ? swap.executed.quoteCurrencyAmount : swap.executed.baseCurrencyAmount;
 			}
 
 			return overview;
@@ -116,7 +107,7 @@ class SwapDetails extends React.Component {
 			<div className="modal-wrapper">
 				<Modal
 					className="SwapDetails"
-					title={`${baseCurrency}/${quoteCurrency} Swap \u{00A0}• \u{00A0}${formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}`}
+					title={`${baseCurrency}/${quoteCurrency} ${swap.isSellOrder ? 'Sell' : 'Buy'} Order \u{00A0}• \u{00A0}${formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}`}
 					icon="/assets/swap-icon.svg"
 					open={this.state.isOpen}
 					onClose={this.close}
@@ -124,16 +115,16 @@ class SwapDetails extends React.Component {
 				>
 					<React.Fragment>
 						<div className="section overview">
-							<div className="quote">
-								<CurrencyIcon symbol={quoteCurrency}/>
-								<p>{overviewData.quoteTitle}</p>
-								<p className="amount">{overviewData.quoteAmount} {quoteCurrency}</p>
+							<div className="from">
+								<CurrencyIcon symbol={overviewData.fromCurrency}/>
+								<p>{overviewData.fromTitle}</p>
+								<p className="amount">{overviewData.fromAmount} {overviewData.fromCurrency}</p>
 							</div>
 							<div className="arrow">→</div>
-							<div className="base">
-								<CurrencyIcon symbol={baseCurrency}/>
-								<p>{overviewData.baseTitle}</p>
-								<p className="amount">{overviewData.baseAmount} {baseCurrency}</p>
+							<div className="for">
+								<CurrencyIcon symbol={overviewData.forCurrency}/>
+								<p>{overviewData.forTitle}</p>
+								<p className="amount">{overviewData.forAmount} {overviewData.forCurrency}</p>
 							</div>
 						</div>
 						<div className="section progress">

--- a/app/renderer/components/SwapDetails.js
+++ b/app/renderer/components/SwapDetails.js
@@ -73,7 +73,7 @@ class SwapDetails extends React.Component {
 				<div key={value}>
 					<h6>{title(value)}</h6>
 					<p>
-						<span className="label">{swap.isSellOrder ? 'Sell' : 'Buy'}:</span> {zeroPadFraction(swap[value].baseCurrencyAmount)} {baseCurrency}
+						<span className="label">{title(swap.orderType)}:</span> {zeroPadFraction(swap[value].baseCurrencyAmount)} {baseCurrency}
 						<br/>
 						<span className="label">For:</span> {zeroPadFraction(swap[value].quoteCurrencyAmount)} {quoteCurrency}
 						<br/>
@@ -84,20 +84,21 @@ class SwapDetails extends React.Component {
 		});
 
 		const overviewData = (() => {
+			const isBuyOrder = swap.orderType === 'buy';
 			const overview = {
 				fromTitle: 'Exchanging:',
 				forTitle: 'For:',
-				fromCurrency: swap.isSellOrder ? baseCurrency : quoteCurrency,
-				forCurrency: swap.isSellOrder ? quoteCurrency : baseCurrency,
-				fromAmount: swap.isSellOrder ? swap.broadcast.baseCurrencyAmount : swap.broadcast.quoteCurrencyAmount,
-				forAmount: swap.isSellOrder ? swap.broadcast.quoteCurrencyAmount : swap.broadcast.baseCurrencyAmount,
+				fromCurrency: isBuyOrder ? quoteCurrency : baseCurrency,
+				forCurrency: isBuyOrder ? baseCurrency : quoteCurrency,
+				fromAmount: isBuyOrder ? swap.broadcast.quoteCurrencyAmount : swap.broadcast.baseCurrencyAmount,
+				forAmount: isBuyOrder ? swap.broadcast.baseCurrencyAmount : swap.broadcast.quoteCurrencyAmount,
 			};
 
 			if (swap.executed.quoteCurrencyAmount) {
 				overview.fromTitle = 'You exchanged:';
 				overview.forTitle = 'You received:';
-				overview.fromAmount = swap.isSellOrder ? swap.executed.baseCurrencyAmount : swap.executed.quoteCurrencyAmount;
-				overview.forAmount = swap.isSellOrder ? swap.executed.quoteCurrencyAmount : swap.executed.baseCurrencyAmount;
+				overview.fromAmount = isBuyOrder ? swap.executed.quoteCurrencyAmount : swap.executed.baseCurrencyAmount;
+				overview.forAmount = isBuyOrder ? swap.executed.baseCurrencyAmount : swap.executed.quoteCurrencyAmount;
 			}
 
 			return overview;
@@ -107,7 +108,7 @@ class SwapDetails extends React.Component {
 			<div className="modal-wrapper">
 				<Modal
 					className="SwapDetails"
-					title={`${baseCurrency}/${quoteCurrency} ${swap.isSellOrder ? 'Sell' : 'Buy'} Order \u{00A0}• \u{00A0}${formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}`}
+					title={`${baseCurrency}/${quoteCurrency} ${title(swap.orderType)} Order \u{00A0}• \u{00A0}${formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}`}
 					icon="/assets/swap-icon.svg"
 					open={this.state.isOpen}
 					onClose={this.close}

--- a/app/renderer/components/SwapDetails.scss
+++ b/app/renderer/components/SwapDetails.scss
@@ -25,8 +25,8 @@
 			margin: 0 50px;
 		}
 
-		.quote,
-		.base {
+		.from,
+		.for {
 			display: flex;
 			flex-direction: column;
 			align-items: center;

--- a/app/renderer/components/SwapList.js
+++ b/app/renderer/components/SwapList.js
@@ -39,11 +39,11 @@ class CancelButton extends React.Component {
 }
 
 const SwapItem = ({swap, showCancel}) => (
-	<div className="row">
+	<div className={`row ${swap.isSellOrder ? 'sell' : 'buy'}`}>
 		<div className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}</div>
 		<div className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</div>
-		<div className="base-amount">+{swap.baseCurrencyAmount} {swap.baseCurrency}</div>
-		<div className="quote-amount">-{swap.quoteCurrencyAmount} {swap.quoteCurrency}</div>
+		<div className="base-amount">{swap.baseCurrencyAmount} {swap.baseCurrency}</div>
+		<div className="quote-amount">{swap.quoteCurrencyAmount} {swap.quoteCurrency}</div>
 		<div className="status">
 			<div className="status__icon" data-status={swap.status}>{swap.statusFormatted}</div>
 		</div>

--- a/app/renderer/components/SwapList.js
+++ b/app/renderer/components/SwapList.js
@@ -39,7 +39,7 @@ class CancelButton extends React.Component {
 }
 
 const SwapItem = ({swap, showCancel}) => (
-	<div className={`row ${swap.isSellOrder ? 'sell' : 'buy'}`}>
+	<div className={`row ${swap.orderType}`}>
 		<div className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}</div>
 		<div className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</div>
 		<div className="base-amount">{swap.baseCurrencyAmount} {swap.baseCurrency}</div>

--- a/app/renderer/components/SwapList.scss
+++ b/app/renderer/components/SwapList.scss
@@ -94,21 +94,19 @@
 	.buy .quote-amount,
 	.sell .base-amount {
 		color: var(--red-color);
-	}
 
-	.buy .quote-amount::before,
-	.sell .base-amount::before {
-		content: '-';
+		&::before {
+			content: '-';
+		}
 	}
 
 	.sell .quote-amount,
 	.buy .base-amount {
 		color: var(--green-color);
-	}
 
-	.sell .quote-amount::before,
-	.buy .base-amount::before {
-		content: '+';
+		&::before {
+			content: '+';
+		}
 	}
 
 	.status {

--- a/app/renderer/components/SwapList.scss
+++ b/app/renderer/components/SwapList.scss
@@ -91,12 +91,24 @@
 		color: var(--text-color);
 	}
 
-	.quote-amount {
+	.buy .quote-amount,
+	.sell .base-amount {
 		color: var(--red-color);
 	}
 
-	.base-amount {
+	.buy .quote-amount::before,
+	.sell .base-amount::before {
+		content: '-';
+	}
+
+	.sell .quote-amount,
+	.buy .base-amount {
 		color: var(--green-color);
+	}
+
+	.sell .quote-amount::before,
+	.buy .base-amount::before {
+		content: '+';
 	}
 
 	.status {

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -91,6 +91,11 @@ class SwapDB {
 
 		const {uuid, timeStarted, request, response, messages} = data;
 
+		// If we place a sell order marketmaker just inverts the values and places a buy
+		// on the opposite pair. We need to normalise this otherwise we'll show the
+		// wrong base/quote currencies.
+		const isSellOrder = (request.quoteCurrency === response.base);
+
 		const swap = {
 			uuid,
 			timeStarted,
@@ -104,9 +109,9 @@ class SwapDB {
 			quoteCurrencyAmount: roundTo(response.relvalue, 8),
 			price: roundTo(response.relvalue / response.basevalue, 8),
 			requested: {
-				baseCurrencyAmount: roundTo(request.amount, 8),
-				quoteCurrencyAmount: roundTo(request.total, 8),
-				price: roundTo(request.price, 8),
+				baseCurrencyAmount: roundTo(isSellOrder ? request.total : request.amount, 8),
+				quoteCurrencyAmount: roundTo(isSellOrder ? request.amount : request.total, 8),
+				price: roundTo(isSellOrder ? (request.amount / request.total) : request.price, 8),
 			},
 			broadcast: {
 				baseCurrencyAmount: roundTo(response.basevalue, 8),

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -95,28 +95,31 @@ class SwapDB {
 		// on the opposite pair. We need to normalise this otherwise we'll show the
 		// wrong base/quote currencies.
 		const isSellOrder = (request.quoteCurrency === response.base);
+		const responseBaseCurrencyAmount = isSellOrder ? response.relvalue : response.basevalue;
+		const responseQuoteCurrencyAmount = isSellOrder ? response.basevalue : response.relvalue;
 
 		const swap = {
 			uuid,
 			timeStarted,
+			isSellOrder,
 			status: 'pending',
 			statusFormatted: 'pending',
 			error: false,
 			progress: 0,
-			baseCurrency: response.base,
-			quoteCurrency: response.rel,
-			baseCurrencyAmount: roundTo(response.basevalue, 8),
-			quoteCurrencyAmount: roundTo(response.relvalue, 8),
-			price: roundTo(response.relvalue / response.basevalue, 8),
+			baseCurrency: request.baseCurrency,
+			quoteCurrency: request.quoteCurrency,
+			baseCurrencyAmount: roundTo(responseBaseCurrencyAmount, 8),
+			quoteCurrencyAmount: roundTo(responseQuoteCurrencyAmount, 8),
+			price: roundTo(responseQuoteCurrencyAmount / responseBaseCurrencyAmount, 8),
 			requested: {
-				baseCurrencyAmount: roundTo(isSellOrder ? request.total : request.amount, 8),
-				quoteCurrencyAmount: roundTo(isSellOrder ? request.amount : request.total, 8),
-				price: roundTo(isSellOrder ? (request.amount / request.total) : request.price, 8),
+				baseCurrencyAmount: roundTo(request.amount, 8),
+				quoteCurrencyAmount: roundTo(request.total, 8),
+				price: roundTo(request.price, 8),
 			},
 			broadcast: {
-				baseCurrencyAmount: roundTo(response.basevalue, 8),
-				quoteCurrencyAmount: roundTo(response.relvalue, 8),
-				price: roundTo(response.relvalue / response.basevalue, 8),
+				baseCurrencyAmount: roundTo(responseBaseCurrencyAmount, 8),
+				quoteCurrencyAmount: roundTo(responseQuoteCurrencyAmount, 8),
+				price: roundTo(responseQuoteCurrencyAmount / responseBaseCurrencyAmount, 8),
 			},
 			executed: {
 				baseCurrencyAmount: undefined,
@@ -159,13 +162,18 @@ class SwapDB {
 					amount: message.srcamount,
 				});
 
-				swap.baseCurrencyAmount = roundTo(message.srcamount, 8);
-				swap.quoteCurrencyAmount = roundTo(message.destamount, 8);
-				swap.price = roundTo(message.destamount / message.srcamount, 8);
+				const executedBaseCurrencyAmount = isSellOrder ? message.destamount : message.srcamount;
+				const executedQuoteCurrencyAmount = isSellOrder ? message.srcamount : message.destamount;
+				swap.baseCurrencyAmount = roundTo(executedBaseCurrencyAmount, 8);
+				swap.quoteCurrencyAmount = roundTo(executedQuoteCurrencyAmount, 8);
+				swap.price = roundTo(executedQuoteCurrencyAmount / executedBaseCurrencyAmount, 8);
 				swap.executed.baseCurrencyAmount = swap.baseCurrencyAmount;
 				swap.executed.quoteCurrencyAmount = swap.quoteCurrencyAmount;
 				swap.executed.price = swap.price;
 				swap.executed.percentCheaperThanRequested = roundTo(100 - ((swap.executed.price / swap.requested.price) * 100), 2);
+				if (isSellOrder) {
+					swap.executed.percentCheaperThanRequested = -swap.executed.percentCheaperThanRequested;
+				}
 			}
 
 			if (message.method === 'failed') {

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -94,14 +94,14 @@ class SwapDB {
 		// If we place a sell order marketmaker just inverts the values and places a buy
 		// on the opposite pair. We need to normalise this otherwise we'll show the
 		// wrong base/quote currencies.
-		const isSellOrder = (request.quoteCurrency === response.base);
-		const responseBaseCurrencyAmount = isSellOrder ? response.relvalue : response.basevalue;
-		const responseQuoteCurrencyAmount = isSellOrder ? response.basevalue : response.relvalue;
+		const isBuyOrder = (request.baseCurrency === response.base);
+		const responseBaseCurrencyAmount = isBuyOrder ? response.basevalue : response.relvalue;
+		const responseQuoteCurrencyAmount = isBuyOrder ? response.relvalue : response.basevalue;
 
 		const swap = {
 			uuid,
 			timeStarted,
-			isSellOrder,
+			orderType: isBuyOrder ? 'buy' : 'sell',
 			status: 'pending',
 			statusFormatted: 'pending',
 			error: false,
@@ -162,8 +162,8 @@ class SwapDB {
 					amount: message.srcamount,
 				});
 
-				const executedBaseCurrencyAmount = isSellOrder ? message.destamount : message.srcamount;
-				const executedQuoteCurrencyAmount = isSellOrder ? message.srcamount : message.destamount;
+				const executedBaseCurrencyAmount = isBuyOrder ? message.srcamount : message.destamount;
+				const executedQuoteCurrencyAmount = isBuyOrder ? message.destamount : message.srcamount;
 				swap.baseCurrencyAmount = roundTo(executedBaseCurrencyAmount, 8);
 				swap.quoteCurrencyAmount = roundTo(executedQuoteCurrencyAmount, 8);
 				swap.price = roundTo(executedQuoteCurrencyAmount / executedBaseCurrencyAmount, 8);
@@ -171,7 +171,7 @@ class SwapDB {
 				swap.executed.quoteCurrencyAmount = swap.quoteCurrencyAmount;
 				swap.executed.price = swap.price;
 				swap.executed.percentCheaperThanRequested = roundTo(100 - ((swap.executed.price / swap.requested.price) * 100), 2);
-				if (isSellOrder) {
+				if (!isBuyOrder) {
 					swap.executed.percentCheaperThanRequested = -swap.executed.percentCheaperThanRequested;
 				}
 			}

--- a/app/renderer/views/Exchange/Swaps.js
+++ b/app/renderer/views/Exchange/Swaps.js
@@ -34,14 +34,10 @@ const All = () => (
 const Split = () => {
 	const {state} = exchangeContainer;
 
-	const filteredData = state.swapHistory.filter(swap => {
-		const tradingPair = [state.baseCurrency, state.quoteCurrency];
-
-		return (
-			tradingPair.includes(swap.baseCurrency) &&
-			tradingPair.includes(swap.quoteCurrency)
-		);
-	});
+	const filteredData = state.swapHistory.filter(x =>
+		x.baseCurrency === state.baseCurrency &&
+		x.quoteCurrency === state.quoteCurrency
+	);
 
 	return (
 		<SwapList swaps={filteredData}/>


### PR DESCRIPTION
Additional fix for: https://github.com/lukechilds/hyperdex/pull/192

This correctly handles inverse values for sell orders. When we place a sell order `marketmaker` just inverts the values and places a buy order on the opposite pair. 

We need to account for this otherwise if we refer to the base/quote currency value in our request it will be the opposite currency in the pair to what we get in `marketmaker` responses.

Before:

<sup>Notice the values in the "Requested" section doesn't match the other sections</sup>

![screen shot 2018-06-13 at 7 04 16 pm](https://user-images.githubusercontent.com/2123375/41350352-1782fe9e-6f3d-11e8-9579-46562c120f48.png)

After:

![screen shot 2018-06-13 at 7 03 43 pm](https://user-images.githubusercontent.com/2123375/41350361-1f73d16e-6f3d-11e8-9f70-18410299bff2.png)
