### PR TITLE
Stuck pending swaps

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -33,6 +33,11 @@ class SwapDB {
 		this.ready = (async () => {
 			await this.db.createIndex({index: {fields: ['timeStarted', 'uuid']}});
 			await this.migrate();
+
+			// We need to regularly check if pending swaps have timed out.
+			// https://github.com/jl777/SuperNET/issues/775
+			const ONE_MINUTE = 60000;
+			setInterval(() => ee.emit('change'), ONE_MINUTE);
 		})();
 
 		this.pQueue = new PQueue({concurrency: 1});

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -173,22 +173,22 @@ class SwapDB {
 					message: `Error Code: ${message.error}`,
 				};
 			}
-
-			swap.statusFormatted = swap.status;
-			if (swap.status === 'swapping') {
-				const swapProgress = swap.transactions
-					.map(tx => tx.stage)
-					.reduce((prevStageLevel, stage) => {
-						const newStageLevel = swapTransactions.indexOf(stage) + 1;
-						return Math.max(prevStageLevel, newStageLevel);
-					}, 0);
-
-				swap.statusFormatted = `swap ${swapProgress}/${swapTransactions.length}`;
-				swap.progress = (swapProgress + MATCHED_STEP) / TOTAL_PROGRESS_STEPS;
-			} else if (swap.status === 'failed' && message.error === -9999) {
-				swap.statusFormatted = 'unmatched';
-			}
 		});
+
+		swap.statusFormatted = swap.status;
+		if (swap.status === 'swapping') {
+			const swapProgress = swap.transactions
+				.map(tx => tx.stage)
+				.reduce((prevStageLevel, stage) => {
+					const newStageLevel = swapTransactions.indexOf(stage) + 1;
+					return Math.max(prevStageLevel, newStageLevel);
+				}, 0);
+
+			swap.statusFormatted = `swap ${swapProgress}/${swapTransactions.length}`;
+			swap.progress = (swapProgress + MATCHED_STEP) / TOTAL_PROGRESS_STEPS;
+		} else if (swap.status === 'failed' && swap.error.code === -9999) {
+			swap.statusFormatted = 'unmatched';
+		}
 
 		return swap;
 	}

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -36,7 +36,7 @@ class SwapDB {
 
 			// We need to regularly check if pending swaps have timed out.
 			// https://github.com/jl777/SuperNET/issues/775
-			const ONE_MINUTE = 60000;
+			const ONE_MINUTE = 1000 * 60;
 			setInterval(() => ee.emit('change'), ONE_MINUTE);
 		})();
 


### PR DESCRIPTION
Resolves #279 

There is a bug in `marketmaker` when a swap get's some communication from a peer (like a `reserved` message) but never matches. In this scenario an error message is never sent so the swap is displayed as pending in the GUI forever.

This is a bit of a hack but it resolves the issue and should be fine until `marketmaker` v2.

It just displays swaps that are pending for more the 5 minutes as unmatched and emits a fake DB change event every minute to force a recalculation.

`marketmaker` issue: https://github.com/jl777/SuperNET/issues/775